### PR TITLE
deb: add metadata for deb package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,18 @@ clap = "3.0.0-beta.1"
 colored = "1.9.3"
 which = "4.0.0"
 # bus_writer = "0.1"
+
+[package.metadata.deb]
+maintainer = "Rami3L <rami3l@outlook.com>"
+copyright = "2020, Rami3L"
+# license-file = ["LICENSE", "4"]
+extended-description = """\
+A Rust port of icy/pacapt, a wrapper for many package managers with \
+pacman-style command syntax."""
+depends = "$auto"
+section = "utility"
+priority = "optional"
+assets = [
+    ["target/release/pacaptr", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/pacaptr/README", "644"],
+]


### PR DESCRIPTION
The meaning of all fields can be found [here](https://docs.rs/crate/cargo-deb).

If you want to change the `extended-description` field, please refer to [here](https://www.debian.org/doc/debian-policy/ch-binary.html#the-description-of-a-package).

The `license-file` field will cause my lintian (v2.80.0) to report an error (copyright-not-using-common-license-for-gpl), so it is temporarily commented.