### PR TITLE
chore: Remove a majority of `cargo clippy` warnings

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -84,9 +84,9 @@ fn exec_checkall(
 
     for mb in stdout_reader.bytes() {
         let b = mb?;
-        out.write(&[b])?;
+        out.write_all(&[b])?;
         if !mute {
-            stdout.write(&[b])?;
+            stdout.write_all(&[b])?;
         }
     }
 
@@ -117,9 +117,9 @@ fn exec_checkerr(
 
     for mb in stderr_reader.bytes() {
         let b = mb?;
-        out.write(&[b])?;
+        out.write_all(&[b])?;
         if !mute {
-            stderr.write(&[b])?;
+            stderr.write_all(&[b])?;
         }
     }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -145,7 +145,7 @@ pub fn prompt(question: &str, options: &str, expected: &[&str], case_sensitive: 
             if let Some('\r') = answer.chars().next_back() {
                 answer.pop();
             }
-            if expected.iter().find(|&&x| x == &answer).is_some() {
+            if expected.iter().any(|&x| x == answer) {
                 break answer;
             }
         }

--- a/src/package_manager/apk.rs
+++ b/src/package_manager/apk.rs
@@ -123,7 +123,7 @@ impl PackageManager for Apk {
 
     /// S installs one or more packages by name.
     fn s(&self, kws: &[&str], flags: &[&str]) -> Result<(), Error> {
-        let mut flags: Vec<&str> = flags.iter().cloned().collect();
+        let mut flags: Vec<&str> = flags.to_vec();
         if self.no_cache {
             flags.push("--no-cache");
         }
@@ -162,7 +162,7 @@ impl PackageManager for Apk {
 
     /// Su updates outdated packages.
     fn su(&self, kws: &[&str], flags: &[&str]) -> Result<(), Error> {
-        let mut flags: Vec<&str> = flags.iter().cloned().collect();
+        let mut flags: Vec<&str> = flags.to_vec();
         if self.no_cache {
             flags.push("--no-cache");
         }
@@ -175,7 +175,7 @@ impl PackageManager for Apk {
 
     /// Suy refreshes the local package database, then updates outdated packages.
     fn suy(&self, kws: &[&str], flags: &[&str]) -> Result<(), Error> {
-        let mut flags: Vec<&str> = flags.iter().cloned().collect();
+        let mut flags: Vec<&str> = flags.to_vec();
         if self.no_cache {
             flags.push("--no-cache");
         }
@@ -202,7 +202,7 @@ impl PackageManager for Apk {
 
     /// U upgrades or adds package(s) to the system and installs the required dependencies from sync repositories.
     fn u(&self, kws: &[&str], flags: &[&str]) -> Result<(), Error> {
-        let mut flags: Vec<&str> = flags.iter().cloned().collect();
+        let mut flags: Vec<&str> = flags.to_vec();
         if self.no_cache {
             flags.push("--no-cache");
         }

--- a/src/package_manager/apt.rs
+++ b/src/package_manager/apt.rs
@@ -18,7 +18,7 @@ impl Apt {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("--yes");
         }

--- a/src/package_manager/aptget.rs
+++ b/src/package_manager/aptget.rs
@@ -18,7 +18,7 @@ impl AptGet {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("--yes");
         }

--- a/src/package_manager/chocolatey.rs
+++ b/src/package_manager/chocolatey.rs
@@ -16,7 +16,7 @@ impl Chocolatey {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("--yes");
         }
@@ -38,7 +38,7 @@ impl PackageManager for Chocolatey {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut flags: Vec<&str> = flags.iter().cloned().collect();
+        let mut flags: Vec<&str> = flags.to_vec();
         if self.dry_run {
             flags.push("--what-if");
         }

--- a/src/package_manager/conda.rs
+++ b/src/package_manager/conda.rs
@@ -15,7 +15,7 @@ impl Conda {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("-y");
         }

--- a/src/package_manager/dnf.rs
+++ b/src/package_manager/dnf.rs
@@ -17,7 +17,7 @@ impl Dnf {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("-y");
         }

--- a/src/package_manager/pip.rs
+++ b/src/package_manager/pip.rs
@@ -16,7 +16,7 @@ impl Pip {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("-y");
         }

--- a/src/package_manager/zypper.rs
+++ b/src/package_manager/zypper.rs
@@ -17,7 +17,7 @@ impl Zypper {
         kws: &[&str],
         flags: &[&str],
     ) -> Result<(), Error> {
-        let mut subcmd: Vec<&str> = subcmd.iter().cloned().collect();
+        let mut subcmd: Vec<&str> = subcmd.to_vec();
         if self.no_confirm {
             subcmd.push("-y");
         }


### PR DESCRIPTION
`cargo clippy` was giving over 15 suggestions, which could fill a terminal. 

These suggestions mostly improve expressivity, with only the last one (changing `write()` to `write_all()`) potentially leading to some runtime differences. 

There are three suggestions remaining, which surround the use of `Mutex<bool>` in `src/exec.rs:166`, suggesting that it should be  changed to either an `AtomicBool` or a `Mutex<()>`.