### PR TITLE
feat: use `flag subcommand` from `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap#fbd338ce26dda73cff33a2820891694bfce3d321"
+source = "git+https://github.com/clap-rs/clap#24f5cd65558c11898cecf9456ed2acd5933760e4"
 dependencies = [
  "atty",
  "bitflags",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap#fbd338ce26dda73cff33a2820891694bfce3d321"
+source = "git+https://github.com/clap-rs/clap#24f5cd65558c11898cecf9456ed2acd5933760e4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -195,11 +195,10 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -709,12 +708,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -762,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -849,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1019,18 +1015,18 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "xshell"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb15bb1b41eb14efe628006294c294e10c366e03a0283b9c2063fc27d97934c6"
+checksum = "c640362f1b150e186b76e88606e4b01a7b2f1d56cc50fcc184ddb683fb567c23"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7ed94a2c75b9bcc57031229be2b57ee47ba71122f71aabef8610ec66a97e52"
+checksum = "0607c095c96c1d8420ce4a018a0954fb15d73d5eb59b521a05a0f04cffc05059"
 
 [[package]]
 name = "xtask"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,8 +119,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+source = "git+https://github.com/rami3l/clap?branch=fix/flag-subcmd#97cda88ff2b825d818f8a9d5d6369e01fff08360"
 dependencies = [
  "atty",
  "bitflags",
@@ -131,15 +130,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+source = "git+https://github.com/rami3l/clap?branch=fix/flag-subcmd#97cda88ff2b825d818f8a9d5d6369e01fff08360"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -477,9 +474,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "log"
@@ -545,9 +542,9 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
 name = "pacaptr"
@@ -823,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/rami3l/clap?branch=fix/flag-subcmd#97cda88ff2b825d818f8a9d5d6369e01fff08360"
+source = "git+https://github.com/clap-rs/clap#fbd338ce26dda73cff33a2820891694bfce3d321"
 dependencies = [
  "atty",
  "bitflags",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/rami3l/clap?branch=fix/flag-subcmd#97cda88ff2b825d818f8a9d5d6369e01fff08360"
+source = "git+https://github.com/clap-rs/clap#fbd338ce26dda73cff33a2820891694bfce3d321"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tt-call",
  "which",
  "xshell",
 ]
@@ -913,6 +914,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tt-call"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a879f817fb174ae8372f5bdb7f36b9f7e4a08c9b54a11277836101aa1911836e"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,18 +831,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ prettytable-rs = "0.8.0"
 regex = "1.5.4"
 
 [dev-dependencies]
-xshell = "0.1.13"
+xshell = "0.1.14"
 
 [dependencies]
 async-trait = "0.1.50"
@@ -46,7 +46,7 @@ regex = { version = "1.5.4", default-features = false, features = ["std", "perf"
 serde = { version = "1.0.126", features = ["derive"] }
 tap = "1.0.1"
 thiserror = "1.0.25"
-tokio = { version = "1.6.0", features = [
+tokio = { version = "1.6.1", features = [
   "io-std",
   "io-util",
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ once_cell = "1.7.2"
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.126", features = ["derive"] }
 tap = "1.0.1"
-thiserror = "1.0.24"
+thiserror = "1.0.25"
 tokio = { version = "1.6.0", features = [
   "io-std",
   "io-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ xshell = "0.1.13"
 async-trait = "0.1.50"
 bytes = "1.0.1"
 # clap = "3.0.0-beta.2"
-clap = { git = "https://github.com/rami3l/clap", branch = "fix/flag-subcmd" }
+clap = { git = "https://github.com/clap-rs/clap" }
 colored = "2.0.0"
 confy = "0.4.0"
 dirs-next = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rami3l/pacaptr"
 
 keywords = ["package-management"]
 categories = ["command-line-utilities"]
-description = "A pacman-like wrapper for many package managers."
+description = "Pacman-like syntax wrapper for many package managers."
 
 license = "GPL-3.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tokio = { version = "1.6.0", features = [
 ] }
 tokio-stream = "0.1.6"
 tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
+tt-call = "1.0.7"
 which = "4.1.0"
 
 [package.metadata.deb]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ xshell = "0.1.13"
 [dependencies]
 async-trait = "0.1.50"
 bytes = "1.0.1"
-clap = "3.0.0-beta.2"
+# clap = "3.0.0-beta.2"
+clap = { git = "https://github.com/rami3l/clap", branch = "fix/flag-subcmd" }
 colored = "2.0.0"
 confy = "0.4.0"
 dirs-next = "2.0.0"

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -13,15 +13,15 @@ use tokio::task;
 /// The command line options to be collected.
 #[derive(Debug, Clap)]
 #[clap(
-    about = clap::crate_description!(),
     version = clap::crate_version!(),
     author = clap::crate_authors!(),
     global_setting = AppSettings::ColoredHelp,
     setting = AppSettings::ArgRequiredElseHelp,
 )]
 pub struct Opts {
-    // Main operations, flags and flagcounters.
-    // see: https://www.archlinux.org/pacman/pacman.8.html
+    /// Main operations, flags and flagcounters.
+    ///
+    /// See: https://www.archlinux.org/pacman/pacman.8.html
     #[clap(subcommand)]
     operations: Operations,
 
@@ -29,7 +29,7 @@ pub struct Opts {
     #[clap(
         long = "using",
         alias = "package-manager",
-        alias = "pm",
+        visible_alias = "pm",
         value_name = "pm",
         about = "Specify the package manager to be invoked"
     )]
@@ -37,8 +37,8 @@ pub struct Opts {
 
     #[clap(
         global = true,
-        long = "dryrun",
-        alias = "dry-run",
+        long = "dry-run",
+        visible_alias = "dryrun",
         about = "Perform a dry run"
     )]
     dry_run: bool,
@@ -53,8 +53,8 @@ pub struct Opts {
     #[clap(
         global = true,
         long = "no-confirm",
-        alias = "noconfirm",
-        alias = "yes",
+        visible_alias = "noconfirm",
+        visible_alias = "yes",
         about = "Answer yes to every question"
     )]
     no_confirm: bool,
@@ -62,7 +62,7 @@ pub struct Opts {
     #[clap(
         global = true,
         long = "no-cache",
-        alias = "nocache",
+        visible_alias = "nocache",
         about = "Remove cache after installation"
     )]
     no_cache: bool,
@@ -85,87 +85,194 @@ pub struct Opts {
     extra_flags: Vec<String>,
 }
 
-/// The command line options to be collected.
+/// Main operations, flags and flagcounters.
+///
+/// See: https://www.archlinux.org/pacman/pacman.8.html
 #[derive(Debug, Clap)]
+#[clap(about = clap::crate_description!())]
 pub enum Operations {
-    #[clap(short_flag = 'Q', long_flag = "query")]
+    #[clap(
+        short_flag = 'Q',
+        long_flag = "query",
+        about = "Query the package database."
+    )]
     Query {
-        #[clap(short, long = "changelog")]
+        #[clap(
+            short,
+            long = "changelog",
+            about = "View the ChangeLog of a package if it exists"
+        )]
         c: bool,
 
-        #[clap(short, long = "explicit")]
+        #[clap(
+            short,
+            long = "explicit",
+            about = "Restrict or filter output to explicitly installed packages"
+        )]
         e: bool,
 
-        #[clap(short, long = "info", parse(from_occurrences))]
+        #[clap(
+            short,
+            long = "info",
+            parse(from_occurrences),
+            about = "Display information on a given package"
+        )]
         i: u32,
 
-        #[clap(short, long = "check")]
+        #[clap(
+            short,
+            long = "check",
+            about = "Check that all files owned by the given package(s) are present on the system"
+        )]
         k: bool,
 
-        #[clap(short, long = "list")]
+        #[clap(
+            short,
+            long = "list",
+            about = "List all files owned by a given package"
+        )]
         l: bool,
 
-        #[clap(short, long = "foreign")]
+        #[clap(
+            short,
+            long = "foreign",
+            about = "Restrict or filter output to packages that were not found in the sync database(s)"
+        )]
         m: bool,
 
-        #[clap(short, long = "owns")]
+        #[clap(
+            short,
+            long = "owns",
+            about = "Search for packages that own the specified file(s)"
+        )]
         o: bool,
 
-        #[clap(short, long = "file")]
+        #[clap(
+            short,
+            long = "file",
+            about = "Signifies that the package supplied on the command line is a file and not an entry in the database"
+        )]
         p: bool,
 
-        #[clap(short, long = "search")]
+        #[clap(
+            short,
+            long = "search",
+            about = "Search each locally-installed package for names or descriptions that match regexp"
+        )]
         s: bool,
 
-        #[clap(short, long = "upgrades")]
+        #[clap(
+            short,
+            long = "upgrades",
+            about = "Restrict or filter output to packages that are out-of-date on the local system"
+        )]
         u: bool,
     },
 
-    #[clap(short_flag = 'R', long_flag = "remove")]
+    #[clap(
+        short_flag = 'R',
+        long_flag = "remove",
+        about = "Remove package(s) from the system."
+    )]
     Remove {
-        #[clap(short, long = "nosave")]
+        #[clap(short, long = "nosave", about = "Ignore file backup designations")]
         n: bool,
 
-        #[clap(short, long = "print")]
+        #[clap(
+            short,
+            long = "print",
+            about = "Only print the targets instead of performing the actual operation"
+        )]
         p: bool,
 
-        #[clap(short, long = "recursive", parse(from_occurrences))]
+        #[clap(
+            short,
+            long = "recursive",
+            parse(from_occurrences),
+            about = "Remove package(s) with all their dependencies that are no longer required"
+        )]
         s: u32,
     },
 
-    #[clap(short_flag = 'S', long_flag = "sync")]
+    #[clap(short_flag = 'S', long_flag = "sync", about = "Synchronize packages.")]
     Sync {
-        #[clap(short, long = "clean", parse(from_occurrences))]
+        #[clap(
+            short,
+            long = "clean",
+            parse(from_occurrences),
+            about = "Remove packages that are no longer installed from the cache as well as currently unused sync databases to free up disk space"
+        )]
         c: u32,
 
-        #[clap(short, long = "groups")]
+        #[clap(
+            short,
+            long = "groups",
+            about = "Display all the members for each package group specified"
+        )]
         g: bool,
 
-        #[clap(short, long = "info", parse(from_occurrences))]
+        #[clap(
+            short,
+            long = "info",
+            parse(from_occurrences),
+            about = "Display information on a given sync database package"
+        )]
         i: u32,
 
-        #[clap(short, long = "list")]
+        #[clap(
+            short,
+            long = "list",
+            about = "List all packages in the specified repositories"
+        )]
         l: bool,
 
-        #[clap(short, long = "print")]
+        #[clap(
+            short,
+            long = "print",
+            about = "Only print the targets instead of performing the actual operation"
+        )]
         p: bool,
 
-        #[clap(short, long = "search")]
+        #[clap(
+            short,
+            long = "search",
+            about = "Search each package in the sync databases for names or descriptions that match regexp"
+        )]
         s: bool,
 
-        #[clap(short, long = "sysupgrade")]
+        #[clap(
+            short,
+            long = "sysupgrade",
+            about = "Upgrade all packages that are out-of-date. Each currently-installed package will be examined and upgraded if a newer package exists"
+        )]
         u: bool,
 
-        #[clap(short, long = "downloadonly")]
+        #[clap(
+            short,
+            long = "downloadonly",
+            about = "Retrieve all packages from the server, but do not install/upgrade anything"
+        )]
         w: bool,
 
-        #[clap(short, long = "refresh")]
+        #[clap(
+            short,
+            long = "refresh",
+            about = "Download a fresh copy of the master package database from the server"
+        )]
         y: bool,
     },
 
-    #[clap(short_flag = 'U', long_flag = "update")]
+    #[clap(
+        short_flag = 'U',
+        long_flag = "update",
+        about = "Upgrade or add package(s) to the system and install the required dependencies from sync repositories."
+    )]
     Update {
-        #[clap(short, long = "print")]
+        #[clap(
+            short,
+            long = "print",
+            about = "Only print the targets instead of performing the actual operation"
+        )]
         p: bool,
     },
 }

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -300,7 +300,8 @@ impl Opts {
             // ! eg. `Suy` instead of `Syu`.
             // ! Then, in order to stay coherent with Rust coding style the method name should be `suy`.
 
-            let mut options = "".to_owned();
+            let mut options = String::new();
+
             macro_rules! collect_options {(
                 op: $op:ident,
                 $( mappings: [$( $key:ident -> $val:ident ), *], )?
@@ -367,14 +368,10 @@ impl Opts {
                 },
             }
 
-            options
-                .chars()
-                .collect_vec()
-                .tap_mut(|chars| chars.sort_unstable())
-                .pipe(String::from_iter)
+            options.chars().sorted_unstable().pipe(String::from_iter)
         };
 
-        let pm: Box<dyn Pm> = cfg.into();
+        let pm = cfg.conv::<Box<dyn Pm>>();
 
         let kws = self.keywords.iter().map(|s| s.as_ref()).collect_vec();
         let flags = self.extra_flags.iter().map(|s| s.as_ref()).collect_vec();
@@ -556,9 +553,7 @@ pub(super) mod tests {
         let opt = dbg!(Opts::parse_from(&["pacaptr", "-Syu"]));
         let subcmd = &opt.operations;
 
-        assert!(matches!(subcmd, &Operations::Sync{
-            u, y, ..
-        } if y && u));
+        assert!(matches!(subcmd, &Operations::Sync{ u, y, .. } if y && u));
         assert!(opt.keywords.is_empty());
 
         opt.dispatch_from(MOCK_CFG.clone()).await.unwrap();

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -4,7 +4,6 @@ use crate::{
     exec::StatusCode,
     methods,
     pm::Pm,
-    print::uppercase_first_char,
 };
 use clap::{self, AppSettings, Clap};
 use itertools::Itertools;
@@ -257,10 +256,8 @@ impl Pacaptr {
         ) => {
             match options.to_lowercase().as_ref() {
                 $(stringify!($method) => pm.$method(&kws, &flags).await,)*
-                invalid => invalid.pipe(uppercase_first_char).pipe(|i| {
-                    Err(Error::ArgParseError {
-                        msg: format!("Invalid flag combination `-{}`", i),
-                    })
+                _ => Err(Error::ArgParseError {
+                    msg: format!("Invalid flag combination `-{}`", &options),
                 }),
             }
         };}

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -25,65 +25,44 @@ pub struct Opts {
     #[clap(subcommand)]
     operations: Operations,
 
-    // Other Pacaptr flags.
+    /// Specify the package manager to be invoked.
     #[clap(
         global = true,
         number_of_values = 1,
         long = "using",
         alias = "package-manager",
         visible_alias = "pm",
-        value_name = "pm",
-        about = "Specify the package manager to be invoked"
+        value_name = "pm"
     )]
     using: Option<String>,
 
-    #[clap(
-        global = true,
-        long = "dry-run",
-        visible_alias = "dryrun",
-        about = "Perform a dry run"
-    )]
+    /// Perform a dry run.
+    #[clap(global = true, long = "dry-run", visible_alias = "dryrun")]
     dry_run: bool,
 
-    #[clap(
-        global = true,
-        long = "needed",
-        about = "Prevent reinstalling packages already installed"
-    )]
+    /// Prevent reinstalling packages already installed.
+    #[clap(global = true, long = "needed")]
     needed: bool,
 
+    /// Answer yes to every question.
     #[clap(
         global = true,
         long = "no-confirm",
         visible_alias = "noconfirm",
-        visible_alias = "yes",
-        about = "Answer yes to every question"
+        visible_alias = "yes"
     )]
     no_confirm: bool,
 
-    #[clap(
-        global = true,
-        long = "no-cache",
-        visible_alias = "nocache",
-        about = "Remove cache after installation"
-    )]
+    /// Remove cache after installation.
+    #[clap(global = true, long = "no-cache", visible_alias = "nocache")]
     no_cache: bool,
 
-    // Keywords
-    #[clap(
-        global = true,
-        name = "KEYWORDS",
-        about = "Package name or (sometimes) regex"
-    )]
+    /// Package name or (sometimes) regex.
+    #[clap(global = true, name = "KEYWORDS")]
     keywords: Vec<String>,
 
-    // Extra Non-Pacaptr Flags
-    #[clap(
-        last = true,
-        global = true,
-        name = "EXTRA_FLAGS",
-        about = "Extra Flags passed directly to backend"
-    )]
+    /// Extra Flags passed directly to backend.
+    #[clap(last = true, global = true, name = "EXTRA_FLAGS")]
     extra_flags: Vec<String>,
 }
 
@@ -93,188 +72,111 @@ pub struct Opts {
 #[derive(Debug, Clap)]
 #[clap(about = clap::crate_description!())]
 pub enum Operations {
-    #[clap(
-        short_flag = 'Q',
-        long_flag = "query",
-        about = "Query the package database."
-    )]
+    /// Query the package database.
+    #[clap(short_flag = 'Q', long_flag = "query")]
     Query {
-        #[clap(
-            short,
-            long = "changelog",
-            about = "View the ChangeLog of a package if it exists"
-        )]
+        /// View the ChangeLog of a package if it exists.
+        #[clap(short, long = "changelog")]
         c: bool,
 
-        #[clap(
-            short,
-            long = "explicit",
-            about = "Restrict or filter output to explicitly installed packages"
-        )]
+        /// Restrict or filter output to explicitly installed packages.
+        #[clap(short, long = "explicit")]
         e: bool,
 
-        #[clap(
-            short,
-            long = "info",
-            parse(from_occurrences),
-            about = "Display information on a given package"
-        )]
+        /// Display information on a given package.
+        #[clap(short, long = "info", parse(from_occurrences))]
         i: u32,
 
-        #[clap(
-            short,
-            long = "check",
-            about = "Check that all files owned by the given package(s) are present on the system"
-        )]
+        /// Check that all files owned by the given package(s) are present on the system.
+        #[clap(short, long = "check")]
         k: bool,
 
-        #[clap(
-            short,
-            long = "list",
-            about = "List all files owned by a given package"
-        )]
+        /// List all files owned by a given package.
+        #[clap(short, long = "list")]
         l: bool,
 
-        #[clap(
-            short,
-            long = "foreign",
-            about = "Restrict or filter output to packages that were not found in the sync database(s)"
-        )]
+        /// Restrict or filter output to packages that were not found in the sync database(s).
+        #[clap(short, long = "foreign")]
         m: bool,
 
-        #[clap(
-            short,
-            long = "owns",
-            about = "Search for packages that own the specified file(s)"
-        )]
+        /// Search for packages that own the specified file(s).
+        #[clap(short, long = "owns")]
         o: bool,
 
-        #[clap(
-            short,
-            long = "file",
-            about = "Signifies that the package supplied on the command line is a file and not an entry in the database"
-        )]
+        /// Signifies that the package supplied on the command line is a file and not an entry in the database.
+        #[clap(short, long = "file")]
         p: bool,
 
-        #[clap(
-            short,
-            long = "search",
-            about = "Search each locally-installed package for names or descriptions that match regexp"
-        )]
+        /// Search each locally-installed package for names or descriptions that match regexp.
+        #[clap(short, long = "search")]
         s: bool,
 
-        #[clap(
-            short,
-            long = "upgrades",
-            about = "Restrict or filter output to packages that are out-of-date on the local system"
-        )]
+        /// Restrict or filter output to packages that are out-of-date on the local system.
+        #[clap(short, long = "upgrades")]
         u: bool,
     },
 
-    #[clap(
-        short_flag = 'R',
-        long_flag = "remove",
-        about = "Remove package(s) from the system."
-    )]
+    /// Remove package(s) from the system.
+    #[clap(short_flag = 'R', long_flag = "remove")]
     Remove {
-        #[clap(short, long = "nosave", about = "Ignore file backup designations")]
+        /// Ignore file backup designations.
+        #[clap(short, long = "nosave")]
         n: bool,
 
-        #[clap(
-            short,
-            long = "print",
-            about = "Only print the targets instead of performing the actual operation"
-        )]
+        /// Only print the targets instead of performing the actual operation.
+        #[clap(short, long = "print")]
         p: bool,
 
-        #[clap(
-            short,
-            long = "recursive",
-            parse(from_occurrences),
-            about = "Remove package(s) with all their dependencies that are no longer required"
-        )]
+        /// Remove package(s) with all their dependencies that are no longer required.
+        #[clap(short, long = "recursive", parse(from_occurrences))]
         s: u32,
     },
 
-    #[clap(short_flag = 'S', long_flag = "sync", about = "Synchronize packages.")]
+    /// Synchronize packages.
+    #[clap(short_flag = 'S', long_flag = "sync")]
     Sync {
-        #[clap(
-            short,
-            long = "clean",
-            parse(from_occurrences),
-            about = "Remove packages that are no longer installed from the cache as well as currently unused sync databases to free up disk space"
-        )]
+        /// Remove packages that are no longer installed from the cache as well as currently unused sync databases to free up disk space.
+        #[clap(short, long = "clean", parse(from_occurrences))]
         c: u32,
 
-        #[clap(
-            short,
-            long = "groups",
-            about = "Display all the members for each package group specified"
-        )]
+        /// Display all the members for each package group specified.
+        #[clap(short, long = "groups")]
         g: bool,
 
-        #[clap(
-            short,
-            long = "info",
-            parse(from_occurrences),
-            about = "Display information on a given sync database package"
-        )]
+        /// Display information on a given sync database package.
+        #[clap(short, long = "info", parse(from_occurrences))]
         i: u32,
 
-        #[clap(
-            short,
-            long = "list",
-            about = "List all packages in the specified repositories"
-        )]
+        /// List all packages in the specified repositories.
+        #[clap(short, long = "list")]
         l: bool,
 
-        #[clap(
-            short,
-            long = "print",
-            about = "Only print the targets instead of performing the actual operation"
-        )]
+        /// Only print the targets instead of performing the actual operation.
+        #[clap(short, long = "print")]
         p: bool,
 
-        #[clap(
-            short,
-            long = "search",
-            about = "Search each package in the sync databases for names or descriptions that match regexp"
-        )]
+        /// Search each package in the sync databases for names or descriptions that match regexp.
+        #[clap(short, long = "search")]
         s: bool,
 
-        #[clap(
-            short,
-            long = "sysupgrade",
-            about = "Upgrade all packages that are out-of-date. Each currently-installed package will be examined and upgraded if a newer package exists"
-        )]
+        /// Upgrade all packages that are out-of-date Each currently-installed package will be examined and upgraded if a newer package exists.
+        #[clap(short, long = "sysupgrade")]
         u: bool,
 
-        #[clap(
-            short,
-            long = "downloadonly",
-            about = "Retrieve all packages from the server, but do not install/upgrade anything"
-        )]
+        /// Retrieve all packages from the server, but do not install/upgrade anything.
+        #[clap(short, long = "downloadonly")]
         w: bool,
 
-        #[clap(
-            short,
-            long = "refresh",
-            about = "Download a fresh copy of the master package database from the server"
-        )]
+        /// Download a fresh copy of the master package database from the server.
+        #[clap(short, long = "refresh")]
         y: bool,
     },
 
-    #[clap(
-        short_flag = 'U',
-        long_flag = "update",
-        about = "Upgrade or add package(s) to the system and install the required dependencies from sync repositories."
-    )]
+    /// Upgrade or add package(s) to the system and install the required dependencies from sync repositories.
+    #[clap(short_flag = 'U', long_flag = "update")]
     Update {
-        #[clap(
-            short,
-            long = "print",
-            about = "Only print the targets instead of performing the actual operation"
-        )]
+        /// Only print the targets instead of performing the actual operation.
+        #[clap(short, long = "print")]
         p: bool,
     },
 }

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -250,7 +250,10 @@ impl Pacaptr {
         let flags = self.extra_flags.iter().map(|s| s.as_ref()).collect_vec();
 
         macro_rules! dispatch_match {(
-            methods = [{ $( $method:ident )* }]
+            methods = [{ $(
+                $( #[$meta:meta] )*
+                async fn $method:ident;
+            )* }]
         ) => {
             match options.to_lowercase().as_ref() {
                 $(stringify!($method) => pm.$method(&kws, &flags).await,)*
@@ -299,7 +302,10 @@ pub(super) mod tests {
     }
 
     macro_rules! impl_pm_mock {(
-        methods = [{ $( $method:ident )* }]
+        methods = [{ $(
+            $( #[$meta:meta] )*
+            async fn $method:ident;
+        )* }]
     ) => {
         #[async_trait]
         impl Pm for MockPm {

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -578,7 +578,7 @@ pub(super) mod tests {
 
     #[test]
     #[should_panic(expected = r#"should run: sw ["curl", "wget"]"#)]
-    async fn simple_si() {
+    async fn simple_sw() {
         let opt = dbg!(Opts::parse_from(&["pacaptr", "-Sw", "curl", "wget"]));
         let subcmd = &opt.operations;
 
@@ -620,10 +620,8 @@ pub(super) mod tests {
         assert!(opt.no_confirm);
         assert!(matches!(subcmd, &Operations::Sync { .. }));
         assert_eq!(opt.keywords, &["docker"]);
+        assert_eq!(opt.extra_flags, &["--proxy=localhost:1234"]);
 
-        let mut flags = opt.extra_flags.iter();
-        assert_eq!(flags.next(), Some(&String::from("--proxy=localhost:1234")));
-        assert_eq!(flags.next(), None);
         opt.dispatch_from(MOCK_CFG.clone()).await.unwrap();
     }
 
@@ -645,10 +643,8 @@ pub(super) mod tests {
         assert!(opt.no_confirm);
         assert!(matches!(subcmd, &Operations::Sync { i, .. } if i == 1));
         assert_eq!(opt.keywords, &["docker"]);
+        assert_eq!(opt.extra_flags, &["--proxy=localhost:1234"]);
 
-        let mut flags = opt.extra_flags.iter();
-        assert_eq!(flags.next(), Some(&String::from("--proxy=localhost:1234")));
-        assert_eq!(flags.next(), None);
         opt.dispatch().await.unwrap();
     }
 }

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -411,7 +411,7 @@ pub(super) mod tests {
     }
 
     #[test]
-    #[should_panic(expected = r#"should run: s ["docker", "--proxy=localhost:1234"]"#)]
+    #[should_panic(expected = r#"should run: si ["docker", "--proxy=localhost:1234"]"#)]
     async fn using() {
         let opt = dbg!(Pacaptr::parse_from(&[
             "pacaptr",
@@ -430,6 +430,6 @@ pub(super) mod tests {
         assert_eq!(opt.keywords, &["docker"]);
         assert_eq!(opt.extra_flags, &["--proxy=localhost:1234"]);
 
-        opt.dispatch().await.unwrap();
+        opt.dispatch_from(MOCK_CFG.clone()).await.unwrap();
     }
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -92,7 +92,7 @@ impl From<Config> for Box<dyn Pm> {
             // Tlmgr
             "tlmgr" => Tlmgr { cfg }.boxed(),
 
-            // Test-only Mock Package Manager
+            // Test-only mock package manager
             #[cfg(test)]
             "mockpm" => {
                 use self::cmd::tests::MockPm;

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -8,22 +8,6 @@ pub mod config;
 pub use self::{cmd::Pacaptr, config::Config};
 use crate::{exec::is_exe, pm::*};
 
-/// The list of `pacman` methods supported by `pacaptr`.
-#[macro_export]
-macro_rules! methods {
-    ( $caller:tt ) => {
-        tt_call::tt_return! {
-            $caller
-            methods = [{
-                q qc qe qi qk ql qm qo qp qs qu
-                r rn rns rs rss
-                s sc scc sccc sg si sii sl ss su suy sw sy
-                u
-            }]
-        }
-    };
-}
-
 /// Detects the name of the package manager to be used in auto dispatch.
 pub fn detect_pm_str<'s>() -> &'s str {
     let pairs: &[(&str, &str)] = match () {

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -5,7 +5,7 @@
 mod cmd;
 pub mod config;
 
-pub use self::{cmd::Opts, config::Config};
+pub use self::{cmd::Pacaptr, config::Config};
 use crate::{exec::is_exe, pm::*};
 
 /// Detects the name of the package manager to be used in auto dispatch.

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -92,6 +92,13 @@ impl From<Config> for Box<dyn Pm> {
             // Tlmgr
             "tlmgr" => Tlmgr { cfg }.boxed(),
 
+            // Test-only Mock Package Manager
+            #[cfg(test)]
+            "mockpm" => {
+                use self::cmd::tests::MockPm;
+                MockPm { cfg }.boxed()
+            }
+
             // Unknown package manager X
             x => Unknown::new(x).boxed(),
         }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -8,6 +8,22 @@ pub mod config;
 pub use self::{cmd::Pacaptr, config::Config};
 use crate::{exec::is_exe, pm::*};
 
+/// The list of `pacman` methods supported by `pacaptr`.
+#[macro_export]
+macro_rules! methods {
+    ( $caller:tt ) => {
+        tt_call::tt_return! {
+            $caller
+            methods = [{
+                q qc qe qi qk ql qm qo qp qs qu
+                r rn rns rs rss
+                s sc scc sccc sg si sii sl ss su suy sw sy
+                u
+            }]
+        }
+    };
+}
+
 /// Detects the name of the package manager to be used in auto dispatch.
 pub fn detect_pm_str<'s>() -> &'s str {
     let pairs: &[(&str, &str)] = match () {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use clap::Clap;
 use pacaptr::{
-    dispatch::Opts,
+    dispatch::Pacaptr,
     print::{print_err, PROMPT_ERROR},
 };
 use tap::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let code = Opts::parse()
+    let code = Pacaptr::parse()
         .dispatch()
         .await
         .tap_err(|e| print_err(e, PROMPT_ERROR))

--- a/src/pm/apt.rs
+++ b/src/pm/apt.rs
@@ -48,7 +48,7 @@ impl Pm for Apt {
             .await
     }
 
-    /// Qp queries a package supplied on the command line rather than an entry in the package management database.
+    /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
     async fn qp(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["dpkg-deb", "-I"]).kws(kws).flags(flags))
             .await

--- a/src/pm/dnf.rs
+++ b/src/pm/dnf.rs
@@ -95,7 +95,7 @@ impl Pm for Dnf {
             .await
     }
 
-    /// Qp queries a package supplied on the command line rather than an entry in the package management database.
+    /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
     async fn qp(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["rpm", "-qip"]).kws(kws).flags(flags))
             .await

--- a/src/pm/mod.rs
+++ b/src/pm/mod.rs
@@ -202,37 +202,32 @@ pub trait PmHelper: Pm {
     async fn check_output(&self, mut cmd: Cmd, mode: PmMode, strat: &Strategy) -> Result<Output> {
         let cfg = self.cfg();
         // `--dry-run` should apply to both the main command and the cleanup.
-        macro_rules! run {
-            ( $cmd: expr ) => {
-                async {
-                    let mut curr_cmd = cmd.clone();
-                    let no_confirm = cfg.no_confirm;
-                    if cfg.no_cache {
-                        if let NoCacheStrategy::WithFlags(v) = &strat.no_cache {
-                            curr_cmd.flags.extend(v.to_owned());
-                        }
-                    }
-                    match &strat.prompt {
-                        PromptStrategy::None => curr_cmd.exec(mode.into()).await,
-                        PromptStrategy::CustomPrompt if no_confirm => {
-                            curr_cmd.exec(mode.into()).await
-                        }
-                        PromptStrategy::CustomPrompt => curr_cmd.exec(Mode::Prompt).await,
-                        PromptStrategy::NativeNoConfirm(v) => {
-                            if no_confirm {
-                                curr_cmd.flags.extend(v.to_owned());
-                            }
-                            curr_cmd.exec(mode.into()).await
-                        }
-                        PromptStrategy::NativeConfirm(v) => {
-                            if !no_confirm {
-                                curr_cmd.flags.extend(v.to_owned());
-                            }
-                            curr_cmd.exec(mode.into()).await
-                        }
-                    }
+
+        async fn run(cfg: &Config, cmd: &Cmd, mode: PmMode, strat: &Strategy) -> Result<Output> {
+            let mut curr_cmd = cmd.clone();
+            let no_confirm = cfg.no_confirm;
+            if cfg.no_cache {
+                if let NoCacheStrategy::WithFlags(v) = &strat.no_cache {
+                    curr_cmd.flags.extend(v.to_owned());
                 }
-            };
+            }
+            match &strat.prompt {
+                PromptStrategy::None => curr_cmd.exec(mode.into()).await,
+                PromptStrategy::CustomPrompt if no_confirm => curr_cmd.exec(mode.into()).await,
+                PromptStrategy::CustomPrompt => curr_cmd.exec(Mode::Prompt).await,
+                PromptStrategy::NativeNoConfirm(v) => {
+                    if no_confirm {
+                        curr_cmd.flags.extend(v.to_owned());
+                    }
+                    curr_cmd.exec(mode.into()).await
+                }
+                PromptStrategy::NativeConfirm(v) => {
+                    if !no_confirm {
+                        curr_cmd.flags.extend(v.to_owned());
+                    }
+                    curr_cmd.exec(mode.into()).await
+                }
+            }
         }
 
         let res = match &strat.dry_run {
@@ -241,9 +236,9 @@ pub trait PmHelper: Pm {
                 cmd.flags.extend(v.to_owned());
                 // * A dry run with extra flags does not need `sudo`.
                 cmd = cmd.sudo(false);
-                run!(&cmd).await?
+                run(&cfg, &cmd, mode, strat).await?
             }
-            _ => run!(&cmd).await?,
+            _ => run(&cfg, &cmd, mode, strat).await?,
         };
 
         // Perform the cleanup.
@@ -260,7 +255,6 @@ pub trait PmHelper: Pm {
         // Reset the current status code.
         // If the code is `None`, then the subprocess ends with a signal.
         self.set_code(res.code.unwrap_or(1)).await;
-
         Ok(res)
     }
 

--- a/src/pm/mod.rs
+++ b/src/pm/mod.rs
@@ -29,6 +29,111 @@ use crate::{
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
+use tt_call::tt_call;
+
+/// The list of `pacman` methods supported by `pacaptr`.
+#[macro_export]
+macro_rules! methods {
+    ( $caller:tt ) => {
+        tt_call::tt_return! {
+            $caller
+            methods = [{
+                /// Q generates a list of installed packages.
+                async fn q;
+
+                /// Qc shows the changelog of a package.
+                async fn qc;
+
+                /// Qe lists packages installed explicitly (not as dependencies).
+                async fn qe;
+
+                /// Qi displays local package information: name, version, description, etc.
+                async fn qi;
+
+                /// Qk verifies one or more packages.
+                async fn qk;
+
+                /// Ql displays files provided by local package.
+                async fn ql;
+
+                /// Qm lists packages that are installed but are not available in any installation source (anymore).
+                async fn qm;
+
+                /// Qo queries the package which provides FILE.
+                async fn qo;
+
+                /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
+                async fn qp;
+
+                /// Qs searches locally installed package for names or descriptions.
+                async fn qs;
+
+                /// Qu lists packages which have an update available.
+                async fn qu;
+
+                /// R removes a single package, leaving all of its dependencies installed.
+                async fn r;
+
+                /// Rn removes a package and skips the generation of configuration backup files.
+                async fn rn;
+
+                /// Rns removes a package and its dependencies which are not required by any other installed package,
+                /// and skips the generation of configuration backup files.
+                async fn rns;
+
+                /// Rs removes a package and its dependencies which are not required by any other installed package,
+                /// and not explicitly installed by the user.
+                async fn rs;
+
+                /// Rss removes a package and its dependencies which are not required by any other installed package.
+                async fn rss;
+
+                /// S installs one or more packages by name.
+                async fn s;
+
+                /// Sc removes all the cached packages that are not currently installed, and the unused sync database.
+                async fn sc;
+
+                /// Scc removes all files from the cache.
+                async fn scc;
+
+                /// Sccc ...
+                /// What is this?
+                async fn sccc;
+
+                /// Sg lists all packages belonging to the GROUP.
+                async fn sg;
+
+                /// Si displays remote package information: name, version, description, etc.
+                async fn si;
+
+                /// Sii displays packages which require X to be installed, aka reverse dependencies.
+                async fn sii;
+
+                /// Sl displays a list of all packages in all installation sources that are handled by the packages management.
+                async fn sl;
+
+                /// Ss searches for package(s) by searching the expression in name, description, short description.
+                async fn ss;
+
+                /// Su updates outdated packages.
+                async fn su;
+
+                /// Suy refreshes the local package database, then updates outdated packages.
+                async fn suy;
+
+                /// Sw retrieves all packages from the server, but does not install/upgrade anything.
+                async fn sw;
+
+                /// Sy refreshes the local package database.
+                async fn sy;
+
+                /// U upgrades or adds package(s) to the system and installs the required dependencies from sync repositories.
+                async fn u;
+            }]
+        }
+    };
+}
 
 macro_rules! make_op_body {
     ( $self:ident, $method:ident ) => {{
@@ -40,158 +145,67 @@ macro_rules! make_op_body {
 }
 
 macro_rules! decl_pm {(
-        $(
-            $( #[$meta:meta] )*
-            async fn $method:ident;
-        )*
-    ) => {
-        /// The behaviors of a Package Manager.
-        ///
-        /// For method explanation see: <https://wiki.archlinux.org/index.php/Pacman/Rosetta>
-        /// and <https://wiki.archlinux.org/index.php/Pacman>
-        #[async_trait]
-        pub trait Pm: Sync {
-            /// Gets the name of the package manager.
-            fn name(&self) -> String;
+    methods = [{ $(
+        $( #[$meta:meta] )*
+        async fn $method:ident;
+    )* }]
+) => {
+    /// The behaviors of a Package Manager.
+    ///
+    /// For method explanation see: <https://wiki.archlinux.org/index.php/Pacman/Rosetta>
+    /// and <https://wiki.archlinux.org/index.php/Pacman>
+    #[async_trait]
+    pub trait Pm: Sync {
+        /// Gets the name of the package manager.
+        fn name(&self) -> String;
 
-            /// Gets the config of the package manager.
-            fn cfg(&self) -> &Config;
+        /// Gets the config of the package manager.
+        fn cfg(&self) -> &Config;
 
-            /// Wraps the `Pm` instance in a box.
-            fn boxed<'a>(self) -> Box<dyn Pm + 'a>
-            where
-                Self: Sized + 'a,
-            {
-                Box::new(self)
-            }
-
-            /// Gets the `StatusCode` to be returned.
-            async fn code(&self) -> StatusCode {
-                self.get_set_code(None).await
-            }
-
-            /// Sets the `StatusCode` to be returned.
-            async fn set_code(&self, to: StatusCode) {
-                self.get_set_code(Some(to)).await;
-            }
-
-            /// Gets/Sets the `StatusCode` to be returned.
-            /// If `to` is `Some(n)`, then the current `StatusCode` will be reset to `n`.
-            /// Then the current `StatusCode` will be returned.
-            #[doc(hidden)]
-            async fn get_set_code(&self, to: Option<StatusCode>) -> StatusCode {
-                static CODE: Lazy<Mutex<StatusCode>> = Lazy::new(|| Mutex::new(0));
-                let mut code = CODE.lock().await;
-                if let Some(n) = to {
-                    *code = n;
-                }
-                *code
-            }
-
-            // * Automatically generated methods below... *
-            $(
-                $(#[$meta])*
-                async fn $method(&self, _kws: &[&str], _flags: &[&str]) -> Result<()> {
-                    make_op_body!(self, $method)
-                }
-            )*
+        /// Wraps the `Pm` instance in a box.
+        fn boxed<'a>(self) -> Box<dyn Pm + 'a>
+        where
+            Self: Sized + 'a,
+        {
+            Box::new(self)
         }
-    };
-}
 
-decl_pm! {
-   /// Q generates a list of installed packages.
-   async fn q;
+        /// Gets the `StatusCode` to be returned.
+        async fn code(&self) -> StatusCode {
+            self.get_set_code(None).await
+        }
 
-   /// Qc shows the changelog of a package.
-   async fn qc;
+        /// Sets the `StatusCode` to be returned.
+        async fn set_code(&self, to: StatusCode) {
+            self.get_set_code(Some(to)).await;
+        }
 
-   /// Qe lists packages installed explicitly (not as dependencies).
-   async fn qe;
+        /// Gets/Sets the `StatusCode` to be returned.
+        /// If `to` is `Some(n)`, then the current `StatusCode` will be reset to `n`.
+        /// Then the current `StatusCode` will be returned.
+        #[doc(hidden)]
+        async fn get_set_code(&self, to: Option<StatusCode>) -> StatusCode {
+            static CODE: Lazy<Mutex<StatusCode>> = Lazy::new(|| Mutex::new(0));
+            let mut code = CODE.lock().await;
+            if let Some(n) = to {
+                *code = n;
+            }
+            *code
+        }
 
-   /// Qi displays local package information: name, version, description, etc.
-   async fn qi;
+        // * Automatically generated methods below... *
+        $( $( #[$meta] )*
+        async fn $method(&self, _kws: &[&str], _flags: &[&str]) -> Result<()> {
+            make_op_body!(self, $method)
+        } )*
+    }
+};}
 
-   /// Qk verifies one or more packages.
-   async fn qk;
-
-   /// Ql displays files provided by local package.
-   async fn ql;
-
-   /// Qm lists packages that are installed but are not available in any installation source (anymore).
-   async fn qm;
-
-   /// Qo queries the package which provides FILE.
-   async fn qo;
-
-   /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
-   async fn qp;
-
-   /// Qs searches locally installed package for names or descriptions.
-   async fn qs;
-
-   /// Qu lists packages which have an update available.
-   async fn qu;
-
-   /// R removes a single package, leaving all of its dependencies installed.
-   async fn r;
-
-   /// Rn removes a package and skips the generation of configuration backup files.
-   async fn rn;
-
-   /// Rns removes a package and its dependencies which are not required by any other installed package,
-   /// and skips the generation of configuration backup files.
-   async fn rns;
-
-   /// Rs removes a package and its dependencies which are not required by any other installed package,
-   /// and not explicitly installed by the user.
-   async fn rs;
-
-   /// Rss removes a package and its dependencies which are not required by any other installed package.
-   async fn rss;
-
-   /// S installs one or more packages by name.
-   async fn s;
-
-   /// Sc removes all the cached packages that are not currently installed, and the unused sync database.
-   async fn sc;
-
-   /// Scc removes all files from the cache.
-   async fn scc;
-
-   /// Sccc ...
-   /// What is this?
-   async fn sccc;
-
-   /// Sg lists all packages belonging to the GROUP.
-   async fn sg;
-
-   /// Si displays remote package information: name, version, description, etc.
-   async fn si;
-
-   /// Sii displays packages which require X to be installed, aka reverse dependencies.
-   async fn sii;
-
-   /// Sl displays a list of all packages in all installation sources that are handled by the packages management.
-   async fn sl;
-
-   /// Ss searches for package(s) by searching the expression in name, description, short description.
-   async fn ss;
-
-   /// Su updates outdated packages.
-   async fn su;
-
-   /// Suy refreshes the local package database, then updates outdated packages.
-   async fn suy;
-
-   /// Sw retrieves all packages from the server, but does not install/upgrade anything.
-   async fn sw;
-
-   /// Sy refreshes the local package database.
-   async fn sy;
-
-   /// U upgrades or adds package(s) to the system and installs the required dependencies from sync repositories.
-   async fn u;
+// Send `methods!()` to `decl_pm`, that is,
+// `decl_pm!( methods = [{ q qc qe .. }] )`.
+tt_call! {
+    macro = [{ methods }]
+    ~~> decl_pm
 }
 
 /// Extra implementation helper functions for [`Pm`],
@@ -201,7 +215,6 @@ pub trait PmHelper: Pm {
     /// Executes a command in the context of the [`Pm`] implementation. Returns the [`Output`] of this command.
     async fn check_output(&self, mut cmd: Cmd, mode: PmMode, strat: &Strategy) -> Result<Output> {
         let cfg = self.cfg();
-        // `--dry-run` should apply to both the main command and the cleanup.
 
         async fn run(cfg: &Config, cmd: &Cmd, mode: PmMode, strat: &Strategy) -> Result<Output> {
             let mut curr_cmd = cmd.clone();
@@ -230,6 +243,7 @@ pub trait PmHelper: Pm {
             }
         }
 
+        // `--dry-run` should apply to both the main command and the cleanup.
         let res = match &strat.dry_run {
             DryRunStrategy::PrintCmd if cfg.dry_run => cmd.clone().exec(Mode::PrintCmd).await?,
             DryRunStrategy::WithFlags(v) if cfg.dry_run => {

--- a/src/pm/mod.rs
+++ b/src/pm/mod.rs
@@ -124,7 +124,7 @@ decl_pm! {
    /// Qo queries the package which provides FILE.
    async fn qo;
 
-   /// Qp queries a package supplied on the command line rather than an entry in the package management database.
+   /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
    async fn qp;
 
    /// Qs searches locally installed package for names or descriptions.
@@ -201,7 +201,6 @@ pub trait PmHelper: Pm {
     /// Executes a command in the context of the [`Pm`] implementation. Returns the [`Output`] of this command.
     async fn check_output(&self, mut cmd: Cmd, mode: PmMode, strat: &Strategy) -> Result<Output> {
         let cfg = self.cfg();
-
         // `--dry-run` should apply to both the main command and the cleanup.
         macro_rules! run {
             ( $cmd: expr ) => {

--- a/src/pm/zypper.rs
+++ b/src/pm/zypper.rs
@@ -95,7 +95,7 @@ impl Pm for Zypper {
             .await
     }
 
-    /// Qp queries a package supplied on the command line rather than an entry in the package management database.
+    /// Qp queries a package supplied through a file supplied on the command line rather than an entry in the package management database.
     async fn qp(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["rpm", "-qip"]).kws(kws).flags(flags))
             .await

--- a/src/print.rs
+++ b/src/print.rs
@@ -74,3 +74,21 @@ pub fn print_question(question: &str, options: &str) {
         indent = PROMPT_INDENT
     );
 }
+
+/// Makes the first `char` of a string uppercase.
+///
+/// # Examples
+/// ```rust
+/// use pacaptr::print::uppercase_first_char;
+/// assert_eq!(
+///     uppercase_first_char("hello"),
+///     "Hello",
+/// );
+/// ```
+pub fn uppercase_first_char(s: &str) -> String {
+    let mut chars = s.chars();
+    chars.next().map_or_else(
+        || "".into(),
+        |first| first.to_uppercase().to_string() + chars.as_str(),
+    )
+}

--- a/src/print.rs
+++ b/src/print.rs
@@ -74,21 +74,3 @@ pub fn print_question(question: &str, options: &str) {
         indent = PROMPT_INDENT
     );
 }
-
-/// Makes the first `char` of a string uppercase.
-///
-/// # Examples
-/// ```rust
-/// use pacaptr::print::uppercase_first_char;
-/// assert_eq!(
-///     uppercase_first_char("hello"),
-///     "Hello",
-/// );
-/// ```
-pub fn uppercase_first_char(s: &str) -> String {
-    let mut chars = s.chars();
-    chars.next().map_or_else(
-        || "".into(),
-        |first| first.to_uppercase().to_string() + chars.as_str(),
-    )
-}

--- a/xtask/src/dispatch/mod.rs
+++ b/xtask/src/dispatch/mod.rs
@@ -44,11 +44,9 @@ fn get_ver_from_env() -> Result<String> {
 
 #[macro_export]
 macro_rules! replace {
-    ( $s:expr, $( $x:expr ),* ) => {
-        {
-            let mut s = $s;
-            $(s = s.replace(concat!("{", stringify!($x), "}"), &$x);)*
-            s
-        }
-    };
+    ( $s:expr, $( $x:expr ),* ) => {{
+        let mut s = $s;
+        $(s = s.replace(concat!("{", stringify!($x), "}"), &$x);)*
+        s
+    }};
 }


### PR DESCRIPTION
- Use `flag`s as `subcommands` (made possible by https://github.com/clap-rs/clap/pull/1974).
- Add a huge amount of docstrings from [`pacman(8)`](https://archlinux.org/pacman/pacman.8.html), greatly improving the readability of help messages.