### PR TITLE
fix!(exec): add errors for non-0 return codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "litrs"
@@ -663,9 +663,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -910,18 +910,18 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xshell"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640362f1b150e186b76e88606e4b01a7b2f1d56cc50fcc184ddb683fb567c23"
+checksum = "07a06b78bf7920975954d1bef9dadedbb522dc886e14532b7cd4c83a10601867"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0607c095c96c1d8420ce4a018a0954fb15d73d5eb59b521a05a0f04cffc05059"
+checksum = "d2b955be4ccb0caffb7312052b5b9d31f24cac4c4898869290f1580cb6d73dc2"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = ["dist/**/*", "docs/**/*"]
 # [build-dependencies]
 
 [dev-dependencies]
-xshell = "0.1.14"
+xshell = "0.1.15"
 
 [dependencies]
 async-trait = "0.1.51"
@@ -57,7 +57,7 @@ tokio = { version = "1.11.0", features = [
   "sync",
 ] }
 tokio-stream = "0.1.7"
-tokio-util = { version = "0.6.7", features = ["codec", "compat"] }
+tokio-util = { version = "0.6.8", features = ["codec", "compat"] }
 tt-call = "1.0.8"
 which = "4.2.2"
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Run `pacman -Syu` on the OS of your choice!
     - [`--yes`, `--noconfirm`, `--no-confirm`](#--yes---noconfirm---no-confirm)
     - [`--nocache`, `--no-cache`](#--nocache---no-cache)
   - [Platform-Specific Tips](#platform-specific-tips)
-    - [`brew`](#brew-1)
-    - [`choco`](#choco-1)
-    - [`pip`](#pip)
+    - [For `brew`](#for-brew)
+    - [For `choco`](#for-choco)
+    - [For `pip`](#for-pip)
   - [Postscript](#postscript)
 
 ---
@@ -278,7 +278,7 @@ This option is useful when you want to reduce `Docker` image size, for example.
 
 ## Platform-Specific Tips
 
-### `brew`
+### For `brew`
 
 - Please note that `cask` is for `macOS` only.
 
@@ -298,17 +298,11 @@ This option is useful when you want to reduce `Docker` image size, for example.
   pacaptr -S docker -- --cask
   ```
 
-- To use `-Rss`, you need to install [rmtree] first:
-
-  ```bash
-  brew tap beeftornado/rmtree
-  ```
-
-### `choco`
+### For `choco`
 
 - Don't forget to run in an elevated shell! You can do this easily with tools like [gsudo].
 
-### `pip`
+### For `pip`
 
 - Use `pacaptr --using pip3` if you want to run the `pip3` command.
 

--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -11,7 +11,6 @@ use tt_call::tt_call;
 use crate::{
     dispatch::Config,
     error::{Error, Result},
-    exec::StatusCode,
     methods,
     pm::Pm,
 };
@@ -215,7 +214,7 @@ impl Pacaptr {
     /// # Errors
     /// See [`Error`](crate::error::Error) for a  list of possible errors.
     #[allow(trivial_numeric_casts)]
-    pub async fn dispatch_from(&self, mut cfg: Config) -> Result<StatusCode> {
+    pub async fn dispatch_from(&self, mut cfg: Config) -> Result<()> {
         // Collect options as a `String`, eg. `-S -y -u => "Suy"`.
         // ! HACK: In `Pm` we ensure the Pacman methods are all named with flags in
         // ! ASCII order, ! eg. `Suy` instead of `Syu`.
@@ -290,12 +289,10 @@ impl Pacaptr {
 
         // Send `methods!()` to `dispatch_match`. That is,
         // `dispatch_match!( methods = [{ q qc qe .. }] )`.
-        (tt_call! {
+        tt_call! {
             macro = [{ methods }]
             ~~> dispatch_match
-        })?;
-
-        Ok(pm.code().await)
+        }
     }
 
     /// Runs [`dispatch_from`](Pacaptr::dispatch_from) with automatically
@@ -304,7 +301,7 @@ impl Pacaptr {
     /// # Errors
     /// See [`Error`](crate::error::Error) for a  list of possible errors.
     #[allow(trivial_numeric_casts)]
-    pub async fn dispatch(&self) -> Result<StatusCode> {
+    pub async fn dispatch(&self) -> Result<()> {
         let dotfile = task::block_in_place(Config::try_load);
         let cfg = self.merge_cfg(dotfile?);
         self.dispatch_from(cfg).await
@@ -347,12 +344,6 @@ pub(super) mod tests {
             fn cfg(&self) -> &Config {
                 &self.cfg
             }
-
-            async fn code(&self) -> StatusCode {
-                0
-            }
-
-            async fn set_code(&self, _to: StatusCode) {}
 
             // * Automatically generated methods below... *
             $( async fn $method(&self, kws: &[&str], flags: &[&str]) -> Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@
 use thiserror::Error;
 use tokio::{io, task::JoinError};
 
+use crate::exec::{Output, StatusCode};
+
 /// A specialized [`Result`](std::result::Result) type used by
 /// [`pacaptr`](crate).
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -34,9 +36,18 @@ pub enum Error {
     #[allow(missing_docs)]
     CmdNoHandleError { handle: String },
 
-    /// An [`Cmd`](crate::exec::Cmd) fails to finish.
+    /// An [`Cmd`](crate::exec::Cmd) fails while waiting for it to finish.
     #[error("Subprocess failed while running: {0}")]
     CmdWaitError(io::Error),
+
+    /// An [`Cmd`](crate::exec::Cmd) exits with an error.
+    #[error("Subprocess exited with code {code}")]
+    #[allow(missing_docs)]
+    CmdStatusCodeError { code: StatusCode, output: Output },
+
+    /// An [`Cmd`](crate::exec::Cmd) gets interrupted by a signal.
+    #[error("Subprocess interrupted by signal")]
+    CmdInterruptedError,
 
     /// Error while converting a [`Vec<u8>`] to a [`String`].
     #[error(transparent)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,21 @@
 use clap::Clap;
 use pacaptr::{
     dispatch::Pacaptr,
+    error::Error,
     print::{print_err, PROMPT_ERROR},
 };
 use tap::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let code = Pacaptr::parse()
+    let res = Pacaptr::parse()
         .dispatch()
         .await
-        .tap_err(|e| print_err(e, PROMPT_ERROR))
-        .unwrap_or(1);
+        .tap_err(|e| print_err(e, PROMPT_ERROR));
+    let code = match res {
+        Ok(_) => 0,
+        Err(Error::CmdStatusCodeError { code, .. }) => code,
+        Err(_) => 1,
+    };
     std::process::exit(code)
 }

--- a/src/pm/apk.rs
+++ b/src/pm/apk.rs
@@ -4,13 +4,12 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{NoCacheStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
 use crate::{
-    dispatch::config::Config,
+    dispatch::Config,
     error::Result,
-    exec::{self, Cmd, StatusCode},
+    exec::{self, Cmd},
     print::{self, PROMPT_RUN},
 };
 
@@ -26,7 +25,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Apk {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -44,10 +42,7 @@ impl Apk {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Apk {
-            cfg,
-            code: Mutex::default(),
-        }
+        Apk { cfg }
     }
 }
 
@@ -60,14 +55,6 @@ impl Pm for Apk {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.
@@ -110,8 +97,7 @@ impl Pm for Apk {
         }
         let out_bytes = self
             .check_output(cmd, PmMode::Mute, &Strategy::default())
-            .await?
-            .contents;
+            .await?;
         exec::grep_print(&String::from_utf8(out_bytes)?, kws)
     }
 

--- a/src/pm/apt.rs
+++ b/src/pm/apt.rs
@@ -4,14 +4,9 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{NoCacheStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
-use crate::{
-    dispatch::config::Config,
-    error::Result,
-    exec::{Cmd, StatusCode},
-};
+use crate::{dispatch::Config, error::Result, exec::Cmd};
 
 macro_rules! docs_self {
     () => {
@@ -25,7 +20,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Apt {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -43,10 +37,7 @@ impl Apt {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Apt {
-            cfg,
-            code: Mutex::default(),
-        }
+        Apt { cfg }
     }
 }
 
@@ -59,14 +50,6 @@ impl Pm for Apt {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/brew.rs
+++ b/src/pm/brew.rs
@@ -146,33 +146,6 @@ impl Pm for Brew {
             .await
     }
 
-    /// Rss removes a package and its dependencies which are not required by any
-    /// other installed package.
-    async fn rss(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
-        let strat = Strategy {
-            dry_run: DryRunStrategy::with_flags(&["--dry-run"]),
-            ..Strategy::default()
-        };
-        let err_msg = Cmd::new(&["brew", "rmtree"])
-            .kws(kws)
-            .flags(flags)
-            .pipe(|cmd| self.check_output(cmd, PmMode::default(), &strat))
-            .await?
-            .contents
-            .pipe(String::from_utf8)?;
-
-        let pattern = "Unknown command: rmtree";
-        if !exec::grep(&err_msg, &[pattern])?.is_empty() {
-            print::print_msg(
-                "`rmtree` is not installed. You may install it with the following command:",
-                PROMPT_INFO,
-            );
-            print::print_msg("`brew tap beeftornado/rmtree`", PROMPT_INFO);
-            return Err(Error::OtherError("`rmtree` required".into()));
-        }
-        Ok(())
-    }
-
     /// S installs one or more packages by name.
     async fn s(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         Cmd::new(if self.cfg.needed {

--- a/src/pm/brew.rs
+++ b/src/pm/brew.rs
@@ -4,14 +4,13 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{DryRunStrategy, NoCacheStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
 use crate::{
-    dispatch::config::Config,
-    error::{Error, Result},
-    exec::{self, Cmd, StatusCode},
-    print::{self, PROMPT_INFO, PROMPT_RUN},
+    dispatch::Config,
+    error::Result,
+    exec::{self, Cmd},
+    print::{self, PROMPT_RUN},
 };
 
 macro_rules! docs_self {
@@ -26,7 +25,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Brew {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -48,9 +46,7 @@ impl Brew {
         }
         let out_bytes = self
             .check_output(cmd, PmMode::Mute, &Strategy::default())
-            .await?
-            .contents;
-
+            .await?;
         exec::grep_print(&String::from_utf8(out_bytes)?, kws)?;
         Ok(())
     }
@@ -60,10 +56,7 @@ impl Brew {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Brew {
-            cfg,
-            code: Mutex::default(),
-        }
+        Brew { cfg }
     }
 }
 
@@ -76,14 +69,6 @@ impl Pm for Brew {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/choco.rs
+++ b/src/pm/choco.rs
@@ -4,11 +4,10 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{DryRunStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
-use crate::exec::{Cmd, StatusCode};
-use crate::{dispatch::config::Config, error::Result};
+use crate::exec::Cmd;
+use crate::{dispatch::Config, error::Result};
 
 macro_rules! docs_self {
     () => {
@@ -22,7 +21,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Choco {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -40,10 +38,7 @@ impl Choco {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Choco {
-            cfg,
-            code: Mutex::default(),
-        }
+        Choco { cfg }
     }
 
     async fn check_dry(&self, cmd: Cmd) -> Result<()> {
@@ -62,14 +57,6 @@ impl Pm for Choco {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/emerge.rs
+++ b/src/pm/emerge.rs
@@ -5,14 +5,9 @@ use indoc::indoc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{NoCacheStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
-use crate::{
-    dispatch::config::Config,
-    error::Result,
-    exec::{Cmd, StatusCode},
-};
+use crate::{dispatch::Config, error::Result, exec::Cmd};
 
 macro_rules! docs_self {
     () => {
@@ -26,7 +21,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Emerge {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_ASK: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -49,10 +43,7 @@ impl Emerge {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Emerge {
-            cfg,
-            code: Mutex::default(),
-        }
+        Emerge { cfg }
     }
 }
 
@@ -65,14 +56,6 @@ impl Pm for Emerge {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/mod.rs
+++ b/src/pm/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 use crate::{
     dispatch::Config,
     error::Result,
-    exec::{Cmd, Mode, Output, StatusCode},
+    exec::{Cmd, Mode, Output},
 };
 
 /// The list of [`pacman`](https://wiki.archlinux.org/index.php/Pacman) methods supported by [`pacaptr`](crate).
@@ -211,13 +211,6 @@ pub trait Pm: Sync {
     {
         Box::new(self)
     }
-
-    /// Gets the [`StatusCode`] to be returned.
-    #[must_use]
-    async fn code(&self) -> StatusCode;
-
-    /// Sets the [`StatusCode`] to be returned.
-    async fn set_code(&self, to: StatusCode);
 }
 
 /// Extra implementation helper functions for [`Pm`],
@@ -280,9 +273,6 @@ pub trait PmHelper: Pm {
             };
         }
 
-        // Reset the current status code.
-        // If the code is `None`, then the subprocess ends with a signal.
-        self.set_code(res.code.unwrap_or(1)).await;
         Ok(res)
     }
 

--- a/src/pm/port.rs
+++ b/src/pm/port.rs
@@ -4,14 +4,9 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{NoCacheStrategy, Pm, PmHelper, PmMode, PromptStrategy, Strategy};
-use crate::{
-    dispatch::config::Config,
-    error::Result,
-    exec::{Cmd, StatusCode},
-};
+use crate::{dispatch::Config, error::Result, exec::Cmd};
 
 macro_rules! docs_self {
     () => {
@@ -25,7 +20,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Port {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -43,10 +37,7 @@ impl Port {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Port {
-            cfg,
-            code: Mutex::default(),
-        }
+        Port { cfg }
     }
 }
 
@@ -59,14 +50,6 @@ impl Pm for Port {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/tlmgr.rs
+++ b/src/pm/tlmgr.rs
@@ -4,14 +4,9 @@ use async_trait::async_trait;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use tap::prelude::*;
-use tokio::sync::Mutex;
 
 use super::{DryRunStrategy, Pm, PmHelper, PmMode, Strategy};
-use crate::{
-    dispatch::config::Config,
-    error::Result,
-    exec::{Cmd, StatusCode},
-};
+use crate::{dispatch::Config, error::Result, exec::Cmd};
 
 macro_rules! docs_self {
     () => {
@@ -25,7 +20,6 @@ macro_rules! docs_self {
 #[derive(Debug)]
 pub struct Tlmgr {
     cfg: Config,
-    code: Mutex<StatusCode>,
 }
 
 static STRAT_CHECK_DRY: Lazy<Strategy> = Lazy::new(|| Strategy {
@@ -37,10 +31,7 @@ impl Tlmgr {
     #[must_use]
     #[allow(missing_docs)]
     pub fn new(cfg: Config) -> Self {
-        Tlmgr {
-            cfg,
-            code: Mutex::default(),
-        }
+        Tlmgr { cfg }
     }
 }
 
@@ -53,14 +44,6 @@ impl Pm for Tlmgr {
 
     fn cfg(&self) -> &Config {
         &self.cfg
-    }
-
-    async fn code(&self) -> StatusCode {
-        *self.code.lock().await
-    }
-
-    async fn set_code(&self, to: StatusCode) {
-        *self.code.lock().await = to;
     }
 
     /// Q generates a list of installed packages.

--- a/src/pm/unknown.rs
+++ b/src/pm/unknown.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use indoc::indoc;
 
 use super::Pm;
-use crate::{dispatch::config::Config, exec::StatusCode};
+use crate::dispatch::Config;
 
 macro_rules! docs_self {
     () => {
@@ -42,10 +42,4 @@ impl Pm for Unknown {
     fn cfg(&self) -> &Config {
         &self.cfg
     }
-
-    async fn code(&self) -> StatusCode {
-        0
-    }
-
-    async fn set_code(&self, _to: StatusCode) {}
 }


### PR DESCRIPTION
In previous versions, a non-0 exit code is not considered as an error in the command execution, which has great impact on API design. Now two specific cases of error has been added.