### PR TITLE
api!: minimize public interface

### DIFF
--- a/src/dispatch/cmd.rs
+++ b/src/dispatch/cmd.rs
@@ -72,7 +72,7 @@ pub struct Pacaptr {
 // For details on operations, flags and flagcounters, see: https://www.archlinux.org/pacman/pacman.8.html
 #[derive(Debug, Clap)]
 #[clap(about = clap::crate_description!())]
-pub enum Operations {
+enum Operations {
     /// Query the package database.
     #[clap(short_flag = 'Q', long_flag = "query")]
     Query {
@@ -198,7 +198,7 @@ impl Pacaptr {
     /// Generates current [`Config`] by merging current command line arguments
     /// and options obtained with [`clap`] with the dotfile [`Config`], which
     /// has a lower precedence.
-    pub fn merge_cfg(&self, dotfile: Config) -> Config {
+    fn merge_cfg(&self, dotfile: Config) -> Config {
         Config {
             dry_run: self.dry_run || dotfile.dry_run,
             needed: self.needed || dotfile.dry_run,
@@ -214,7 +214,7 @@ impl Pacaptr {
     /// # Errors
     /// See [`Error`](crate::error::Error) for a  list of possible errors.
     #[allow(trivial_numeric_casts)]
-    pub async fn dispatch_from(&self, mut cfg: Config) -> Result<()> {
+    async fn dispatch_from(&self, mut cfg: Config) -> Result<()> {
         // Collect options as a `String`, eg. `-S -y -u => "Suy"`.
         // ! HACK: In `Pm` we ensure the Pacman methods are all named with flags in
         // ! ASCII order, ! eg. `Suy` instead of `Syu`.
@@ -317,7 +317,7 @@ pub(super) mod tests {
 
     use super::*;
 
-    pub struct MockPm {
+    pub(crate) struct MockPm {
         pub cfg: Config,
     }
 

--- a/src/dispatch/config.rs
+++ b/src/dispatch/config.rs
@@ -13,7 +13,7 @@ const CONFIG_ENV_VAR: &str = "PACAPTR_CONFIG";
 #[must_use]
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct Config {
+pub(crate) struct Config {
     /// Perform a dry run.
     #[serde(default)]
     pub dry_run: bool,
@@ -40,7 +40,7 @@ impl Config {
     ///
     /// # Errors
     /// Returns an [`Error::ConfigError`] when `$HOME` is not found.
-    pub fn default_path() -> Result<PathBuf> {
+    fn default_path() -> Result<PathBuf> {
         let crate_name = clap::crate_name!();
         let home = dirs_next::home_dir().ok_or_else(|| Error::ConfigError {
             msg: "$HOME path not found".into(),
@@ -57,7 +57,7 @@ impl Config {
     /// # Errors
     /// Returns an [`Error::ConfigError`] when the config path is not found in
     /// the environmental variable.
-    pub fn custom_path() -> Result<PathBuf> {
+    fn custom_path() -> Result<PathBuf> {
         env::var(CONFIG_ENV_VAR)
             .map_err(|e| Error::ConfigError {
                 msg: format!("Config path environment variable not found: {}", e),
@@ -75,7 +75,7 @@ impl Config {
     ///
     /// # Errors
     /// Returns an [`Error::ConfigError`] when the config file loading fails.
-    pub fn try_load() -> Result<Self> {
+    pub(crate) fn try_load() -> Result<Self> {
         let path = Config::custom_path().or_else(|_| Config::default_path())?;
         path.exists()
             .then(|| confy::load_path(&path))

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -13,9 +13,10 @@
 //!   above.
 
 mod cmd;
-pub mod config;
+mod config;
 
-pub use self::{cmd::Pacaptr, config::Config};
+pub use self::cmd::Pacaptr;
+pub(crate) use self::config::Config;
 use crate::{
     exec::is_exe,
     pm::{Apk, Apt, Brew, Choco, Conda, Dnf, Emerge, Pip, Pm, Port, Scoop, Tlmgr, Unknown, Zypper},
@@ -23,7 +24,7 @@ use crate::{
 
 /// Detects the name of the package manager to be used in auto dispatch.
 #[must_use]
-pub fn detect_pm_str<'s>() -> &'s str {
+fn detect_pm_str<'s>() -> &'s str {
     let pairs: &[(&str, &str)] = match () {
         _ if cfg!(target_os = "windows") => &[("scoop", ""), ("choco", "")],
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,10 +7,11 @@ use crate::exec::{Output, StatusCode};
 
 /// A specialized [`Result`](std::result::Result) type used by
 /// [`pacaptr`](crate).
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Error type for the [`pacaptr`](crate) library.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Error while parsing CLI arguments.
     #[error("Failed to parse arguments: {msg}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 
 pub mod dispatch;
 pub mod error;
-pub mod exec;
+mod exec;
 
-pub mod pm;
+mod pm;
 pub mod print;

--- a/src/pm/apk.rs
+++ b/src/pm/apk.rs
@@ -23,7 +23,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Apk {
+pub(crate) struct Apk {
     cfg: Config,
 }
 
@@ -41,7 +41,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Apk {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Apk { cfg }
     }
 }

--- a/src/pm/apt.rs
+++ b/src/pm/apt.rs
@@ -18,7 +18,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Apt {
+pub(crate) struct Apt {
     cfg: Config,
 }
 
@@ -36,7 +36,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Apt {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Apt { cfg }
     }
 }

--- a/src/pm/brew.rs
+++ b/src/pm/brew.rs
@@ -23,7 +23,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Brew {
+pub(crate) struct Brew {
     cfg: Config,
 }
 
@@ -55,7 +55,7 @@ impl Brew {
 impl Brew {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Brew { cfg }
     }
 }

--- a/src/pm/choco.rs
+++ b/src/pm/choco.rs
@@ -19,7 +19,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Choco {
+pub(crate) struct Choco {
     cfg: Config,
 }
 
@@ -37,7 +37,7 @@ static STRAT_CHECK_DRY: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Choco {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Choco { cfg }
     }
 

--- a/src/pm/conda.rs
+++ b/src/pm/conda.rs
@@ -24,7 +24,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Conda {
+pub(crate) struct Conda {
     cfg: Config,
 }
 
@@ -36,7 +36,7 @@ static STRAT_PROMPT: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Conda {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Conda { cfg }
     }
 }

--- a/src/pm/dnf.rs
+++ b/src/pm/dnf.rs
@@ -24,7 +24,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Dnf {
+pub(crate) struct Dnf {
     cfg: Config,
 }
 
@@ -47,7 +47,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Dnf {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Dnf { cfg }
     }
 }

--- a/src/pm/emerge.rs
+++ b/src/pm/emerge.rs
@@ -19,7 +19,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Emerge {
+pub(crate) struct Emerge {
     cfg: Config,
 }
 
@@ -42,7 +42,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Emerge {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Emerge { cfg }
     }
 }

--- a/src/pm/pip.rs
+++ b/src/pm/pip.rs
@@ -23,7 +23,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Pip {
+pub(crate) struct Pip {
     cfg: Config,
 }
 
@@ -40,7 +40,7 @@ static STRAT_UNINSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Pip {
     /// Returns the command used to invoke [`Pip`], eg. `pip`, `pip3`.
     #[must_use]
-    pub fn cmd(&self) -> &str {
+    fn cmd(&self) -> &str {
         self.cfg
             .default_pm
             .as_deref()
@@ -51,7 +51,7 @@ impl Pip {
 impl Pip {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Pip { cfg }
     }
 }

--- a/src/pm/port.rs
+++ b/src/pm/port.rs
@@ -18,7 +18,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Port {
+pub(crate) struct Port {
     cfg: Config,
 }
 
@@ -36,7 +36,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Port {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Port { cfg }
     }
 }

--- a/src/pm/scoop.rs
+++ b/src/pm/scoop.rs
@@ -23,7 +23,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Scoop {
+pub(crate) struct Scoop {
     cfg: Config,
 }
 
@@ -41,7 +41,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Scoop {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Scoop { cfg }
     }
 

--- a/src/pm/tlmgr.rs
+++ b/src/pm/tlmgr.rs
@@ -18,7 +18,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Tlmgr {
+pub(crate) struct Tlmgr {
     cfg: Config,
 }
 
@@ -30,7 +30,7 @@ static STRAT_CHECK_DRY: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Tlmgr {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Tlmgr { cfg }
     }
 }

--- a/src/pm/unknown.rs
+++ b/src/pm/unknown.rs
@@ -16,7 +16,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Unknown {
+pub(crate) struct Unknown {
     name: String,
     cfg: Config,
 }
@@ -24,7 +24,7 @@ pub struct Unknown {
 impl Unknown {
     #[must_use]
     /// Creates a new [`Unknown`] package manager with the given name.
-    pub fn new(name: &str) -> Self {
+    pub(crate) fn new(name: &str) -> Self {
         Unknown {
             name: format!("unknown package manager: {}", name),
             cfg: Config::default(),

--- a/src/pm/zypper.rs
+++ b/src/pm/zypper.rs
@@ -22,7 +22,7 @@ macro_rules! docs_self {
 
 #[doc = docs_self!()]
 #[derive(Debug)]
-pub struct Zypper {
+pub(crate) struct Zypper {
     cfg: Config,
 }
 
@@ -46,7 +46,7 @@ static STRAT_INSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 impl Zypper {
     #[must_use]
     #[allow(missing_docs)]
-    pub fn new(cfg: Config) -> Self {
+    pub(crate) fn new(cfg: Config) -> Self {
         Zypper { cfg }
     }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -6,14 +6,14 @@ use colored::Colorize;
 
 use crate::exec::Cmd;
 
-pub static PROMPT_CANCELED: &str = "Canceled";
-pub static PROMPT_PENDING: &str = "Pending";
-pub static PROMPT_RUN: &str = "Running";
-pub static PROMPT_INFO: &str = "Info";
+pub(crate) static PROMPT_CANCELED: &str = "Canceled";
+pub(crate) static PROMPT_PENDING: &str = "Pending";
+pub(crate) static PROMPT_RUN: &str = "Running";
+pub(crate) static PROMPT_INFO: &str = "Info";
 pub static PROMPT_ERROR: &str = "Error";
 
 /// The right indentation to be applied on prompt prefixes.
-pub static PROMPT_INDENT: usize = 9;
+static PROMPT_INDENT: usize = 9;
 
 macro_rules! prompt_format {
     () => {
@@ -40,7 +40,7 @@ macro_rules! question_format {
 }
 
 /// Prints out the command after the given prompt.
-pub fn print_cmd(cmd: &Cmd, prompt: &str) {
+pub(crate) fn print_cmd(cmd: &Cmd, prompt: &str) {
     println!(
         cmd_format!(),
         prompt.green().bold(),
@@ -50,7 +50,7 @@ pub fn print_cmd(cmd: &Cmd, prompt: &str) {
 }
 
 /// Prints out a message after the given prompt.
-pub fn print_msg(msg: &str, prompt: &str) {
+pub(crate) fn print_msg(msg: &str, prompt: &str) {
     println!(
         msg_format!(),
         prompt.green().bold(),
@@ -70,7 +70,7 @@ pub fn print_err(err: impl std::fmt::Display, prompt: &str) {
 }
 
 /// Prints out a question after the given prompt.
-pub fn print_question(question: &str, options: &str) {
+pub(crate) fn print_question(question: &str, options: &str) {
     print!(
         question_format!(),
         question.yellow(),


### PR DESCRIPTION
The current public API is not well considered and suffers from breaking changes.
To facilitate CLI interface stability, the public Rust API is now shrunken to bare minimum. This change might be reverted later.