### PR TITLE
feat(cmd): add new command `-Qii`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "litrs"
@@ -767,18 +767,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
 ]

--- a/crates/pacaptr-macros/src/compat_table.rs
+++ b/crates/pacaptr-macros/src/compat_table.rs
@@ -12,9 +12,9 @@ const PM_IMPL_DIR: &str = "src/pm/";
 
 // We have to specify the length there (the elision is blocked by https://github.com/rust-lang/rfcs/pull/2545).
 // TODO: Fix this when the issue is resolved.
-const METHODS: [&str; 30] = [
-    "q", "qc", "qe", "qi", "qk", "ql", "qm", "qo", "qp", "qs", "qu", "r", "rn", "rns", "rs", "rss",
-    "s", "sc", "scc", "sccc", "sg", "si", "sii", "sl", "ss", "su", "suy", "sw", "sy", "u",
+const METHODS: [&str; 31] = [
+    "q", "qc", "qe", "qi", "qii", "qk", "ql", "qm", "qo", "qp", "qs", "qu", "r", "rn", "rns", "rs",
+    "rss", "s", "sc", "scc", "sccc", "sg", "si", "sii", "sl", "ss", "su", "suy", "sw", "sy", "u",
 ];
 
 /// Checks the implementation status of `pacman` commands in a specific file

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -63,6 +63,9 @@ macro_rules! methods {
                 /// Qi displays local package information: name, version, description, etc.
                 async fn qi;
 
+                /// Qii displays local packages which require X to be installed, aka reverse dependencies.
+                async fn qii;
+
                 /// Qk verifies one or more packages.
                 async fn qk;
 

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -63,7 +63,7 @@ macro_rules! methods {
                 /// Qi displays local package information: name, version, description, etc.
                 async fn qi;
 
-                /// Qii displays local packages which require X to be installed, aka reverse dependencies.
+                /// Qii displays local packages which require X to be installed, aka local reverse dependencies.
                 async fn qii;
 
                 /// Qk verifies one or more packages.

--- a/src/pm/apk.rs
+++ b/src/pm/apk.rs
@@ -71,6 +71,12 @@ impl Pm for Apk {
         self.si(kws, flags).await
     }
 
+    /// Qii displays local packages which require X to be installed, aka local
+    /// reverse dependencies.
+    async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
+        self.sii(kws, flags).await
+    }
+
     /// Ql displays files provided by local package.
     async fn ql(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["apk", "info", "-L"]).kws(kws).flags(flags))

--- a/src/pm/apt.rs
+++ b/src/pm/apt.rs
@@ -79,6 +79,12 @@ impl Pm for Apt {
             .await
     }
 
+    /// Qii displays local packages which require X to be installed, aka local
+    /// reverse dependencies.
+    async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
+        self.sii(kws, flags).await
+    }
+
     /// Qo queries the package which provides FILE.
     async fn qo(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["dpkg-query", "-S"]).kws(kws).flags(flags))

--- a/src/pm/brew.rs
+++ b/src/pm/brew.rs
@@ -90,8 +90,8 @@ impl Pm for Brew {
         self.si(kws, flags).await
     }
 
-    /// Qii displays local packages which require X to be installed, aka reverse
-    /// dependencies.
+    /// Qii displays local packages which require X to be installed, aka local
+    /// reverse dependencies.
     async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         Cmd::new(&["brew", "uses", "--installed"])
             .kws(kws)

--- a/src/pm/brew.rs
+++ b/src/pm/brew.rs
@@ -90,6 +90,16 @@ impl Pm for Brew {
         self.si(kws, flags).await
     }
 
+    /// Qii displays local packages which require X to be installed, aka reverse
+    /// dependencies.
+    async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
+        Cmd::new(&["brew", "uses", "--installed"])
+            .kws(kws)
+            .flags(flags)
+            .pipe(|cmd| self.run(cmd))
+            .await
+    }
+
     /// Ql displays files provided by local package.
     async fn ql(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         // TODO: it seems that the output of `brew list python` in fish has a mechanism

--- a/src/pm/dnf.rs
+++ b/src/pm/dnf.rs
@@ -102,6 +102,12 @@ impl Pm for Dnf {
         .await
     }
 
+    /// Qii displays local packages which require X to be installed, aka local
+    /// reverse dependencies.
+    async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
+        self.qi(kws, flags).await
+    }
+
     /// Ql displays files provided by local package.
     async fn ql(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["rpm", "-ql"]).kws(kws).flags(flags))

--- a/src/pm/xbps.rs
+++ b/src/pm/xbps.rs
@@ -161,6 +161,13 @@ impl Pm for Xbps {
             .await
     }
 
+    /// Qii displays local packages which require X to be installed, aka local
+    /// reverse dependencies.
+    async fn qii(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
+        self.run(Cmd::new(&["xbps-query", "-X"]).kws(kws).flags(flags))
+            .await
+    }
+
     /// Ql displays files provided by local package.
     async fn ql(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
         self.run(Cmd::new(&["xbps-query", "-f"]).kws(kws).flags(flags))


### PR DESCRIPTION
This command is the local version of `-Sii`: it displays *local* packages which require X to be installed, aka local reverse dependencies.