### PR TITLE
fix(pm): determine the shell that runs `scoop` dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![Private APIs](https://img.shields.io/badge/docs-private--apis-lightgrey?style=flat-square)](https://rami3l.github.io/pacaptr/pacaptr)
 [![License](https://img.shields.io/github/license/rami3l/pacaptr?style=flat-square)](LICENSE)
 
-`pac·apt·r`, or the _PACman AdaPTeR_, is a wrapper for many package managers with pacman-style command syntax, started as a Rust port of [icy/pacapt].
+`pac·apt·r`, or the _PACman AdaPTeR_, is a wrapper for many package managers that allows you to use pacman commands with them.
 
 Just set `pacman` as the alias of `pacaptr` on your non-Arch OS, and then you can run `pacman -Syu` wherever you like!
 
@@ -76,7 +76,7 @@ Just set `pacman` as the alias of `pacaptr` on your non-Arch OS, and then you ca
 
 Coming from `Arch Linux` to `macOS`, I really like the idea of having an automated version of [Pacman Rosetta] for making common package managing tasks less of a travail thanks to the concise `pacman` syntax.
 
-That's why I decided to take inspiration from the existing `sh`-based [icy/pacapt] to make a new CLI tool in Rust for better portability (especially for Windows) and easier maintenance.
+That's why I decided to take inspiration from the existing `sh`-based [icy/pacapt] to make a new CLI tool in Rust for better portability (especially for Windows and macOS) and easier maintenance.
 
 ## Supported Package Managers
 
@@ -88,7 +88,7 @@ That's why I decided to take inspiration from the existing `sh`-based [icy/pacap
 - External: `brew`, `conda`, `pip`/`pip3`, `pkcon`, `tlmgr`
   - These are only available with the [`pacaptr --using <name>`](#--using---pm) syntax.
 
-As for now, the precedence is still (unfortunately) hard-coded. For example, if both `scoop` and `choco` are installed, `scoop` will be the default. You can however edit the default package manager in your [config](#configuration).
+As for now, the precedence is still (unfortunately) hard-coded. For example, if both `scoop` and `choco` are installed, `scoop` will be the default. You can, however, edit the default package manager in your [config](#configuration).
 
 Please refer to the [compatibility table] for more details on which operations are supported.
 
@@ -123,7 +123,7 @@ To install the release version from crates.io:
 cargo install pacaptr
 ```
 
-To install `master` version from GitHub:
+To install the `master` version from GitHub:
 
 ```bash
 cargo install pacaptr --git https://github.com/rami3l/pacaptr.git
@@ -142,7 +142,7 @@ To uninstall:
 cargo uninstall pacaptr
 ```
 
-For `Alpine Linux` users, `cargo build` might not just work, in this case, please try the following instead:
+For `Alpine Linux` users, `cargo build` might not just work. Please try the following instead:
 
 ```bash
 RUSTFLAGS="-C target-feature=-crt-static" cargo build
@@ -289,7 +289,7 @@ This option is useful when you want to reduce `Docker` image size, for example.
 
 #### For `scoop`
 
-- `pacaptr` launches a `powershell` subprocess to run `scoop`, so please make sure that you have set the right execution policy in `powershell` ([**not `pwsh`**](https://powershellexplained.com/2017-12-29-Powershell-what-is-pwsh/)):
+- `pacaptr` launches a [`pwsh`](https://powershellexplained.com/2017-12-29-Powershell-what-is-pwsh/) subprocess to run `scoop`, or a `powershell` one if `pwsh` is not found in `$PATH`. Please make sure that you have set the right execution policy in the corresponding shell:
 
   ```pwsh
   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser

--- a/crates/pacaptr-macros/src/compat_table.rs
+++ b/crates/pacaptr-macros/src/compat_table.rs
@@ -79,7 +79,7 @@ fn make_table() -> anyhow::Result<String> {
             let data = METHODS.map(|method| {
                 items
                     .get(method)
-                    .expect("Implementation details not registered")
+                    .expect("implementation details not registered")
                     .then(|| "*")
                     .unwrap_or("")
             });

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -163,7 +163,7 @@ impl Cmd {
             let (cmd, subcmd) = self
                 .cmd
                 .split_first()
-                .expect("Failed to build Cmd, command is empty");
+                .expect("failed to build Cmd, command is empty");
             Exec::new(cmd).tap_mut(|builder| {
                 builder.args(subcmd).args(&self.flags).args(&self.kws);
             })

--- a/src/pm/pip.rs
+++ b/src/pm/pip.rs
@@ -37,6 +37,12 @@ static STRAT_UNINSTALL: Lazy<Strategy> = Lazy::new(|| Strategy {
 });
 
 impl Pip {
+    #[must_use]
+    #[allow(missing_docs)]
+    pub const fn new(cfg: Config) -> Self {
+        Self { cfg }
+    }
+
     /// Returns the command used to invoke [`Pip`], eg. `pip`, `pip3`.
     #[must_use]
     fn cmd(&self) -> &str {
@@ -44,14 +50,6 @@ impl Pip {
             .default_pm
             .as_deref()
             .expect("default package manager should have been assigned before initialization")
-    }
-}
-
-impl Pip {
-    #[must_use]
-    #[allow(missing_docs)]
-    pub const fn new(cfg: Config) -> Self {
-        Self { cfg }
     }
 }
 


### PR DESCRIPTION
When launching a `powershell` subprocess from `pwsh`, `powershell` tries to read `Get-FileHash` and friends from `pwsh`'s `PSModulePath`, causing an `ObjectNotFound` error.
* https://github.com/PowerShell/PowerShell/issues/18681#issuecomment-1331656103
* https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850 

---

This PR makes `pwsh` the shell to invoke `scoop` if it's detected by `which::which` (thus in the `PATH`). `powershell` is still used as a fallback.