### PR TITLE
ci(test): migrate to two-stage smoke tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Create
         run: cargo doc --all-features --document-private-items --no-deps
       # https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,9 @@ jobs:
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      # NOTE: Since Rust is pre-installed in the runner,
+      # it's faster to run `rust-cache` before `rust-toolchain`.
+      # This is not the case for jobs running in Docker images.
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
@@ -247,14 +250,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup extra build tools
         run: dnf install -y make automake gcc gcc-c++ kernel-devel
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
           save-if: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - name: Build and run tests
         env:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
@@ -276,14 +279,14 @@ jobs:
         run: |
           # `pacaptr -Ss` might fail without this line.
           emerge --sync || true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
           save-if: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - name: Build and run tests
         env:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
@@ -305,14 +308,14 @@ jobs:
           xbps-install -y -Su || (xbps-install -y -u xbps && xbps-install -y -Su)
           xbps-install -y base-devel curl bash
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
           save-if: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - name: Build and run tests
         env:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
@@ -332,14 +335,14 @@ jobs:
       - name: Setup extra build tools
         run: zypper install -y tar gzip curl gcc bash
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
           save-if: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - name: Build and run tests
         env:
           CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
@@ -360,14 +363,14 @@ jobs:
         run: |
           apk add -U build-base tar bash
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
       - name: Download cached build
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
           save-if: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - name: Build and run tests
         env:
           RUSTFLAGS: "-C target-feature=-crt-static"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  # https://users.rust-lang.org/t/cross-compiling-how-to-statically-link-glibc/83907/2
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
 
 jobs:
   skip-check:
@@ -23,35 +25,82 @@ jobs:
           concurrent_skipping: same_content
           do_not_skip: '["pull_request"]'
 
+  build:
+    name: build (${{ matrix.target }})
+    needs: skip-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            target2: aarch64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            target2: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            target2: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup extra build tools
+        if: matrix.target2 == 'aarch64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - id: cache_build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+      - name: Setup Rust
+        if: ${{ !steps.cache_build.outputs.cache-hit }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }},${{ matrix.target2 }}
+      - name: Build
+        if: ${{ !steps.cache_build.outputs.cache-hit }}
+        run: |
+          cargo build --verbose --all-targets --target=${{ matrix.target }}
+          cargo build --verbose --release --locked --target=${{ matrix.target2 }}
+
   choco-test:
     runs-on: windows-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-pc-windows-msvc
-      - uses: Swatinem/rust-cache@v2
-      - name: Test build for aarch64
-        run: cargo build --verbose --release --locked --target=aarch64-pc-windows-msvc
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test choco -- --test-threads=1
-      - name: Run heavy tests
-        run: cargo test --features=test choco -- --ignored --test-threads=1
+          targets: x86_64-pc-windows-msvc
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test choco -- --test-threads=1
+          cargo test --features=test choco -- --ignored --test-threads=1
 
   scoop-winget-test:
     runs-on: windows-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        with:
+          targets: x86_64-pc-windows-msvc
       - name: Install scoop
         shell: powershell
         run: |
@@ -72,44 +121,45 @@ jobs:
         run: |
           Get-Command winget
           winget --info
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
         run: |
+          cargo build --verbose
+          cargo test --features=test tests
+
           cargo test --features=test scoop
           cargo test --features=test winget
-      - name: Run heavy tests
-        run: |
+
           cargo test --features=test scoop -- --ignored
           cargo test --features=test winget -- --ignored
 
   brew-test:
     runs-on: macos-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-      - name: Test build for aarch64
-        run: cargo build --verbose --release --locked --target=aarch64-apple-darwin
-      - name: Test native build
-        run: cargo build --verbose
-      # - run: brew list
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test brew
-      - name: Run heavy tests
-        run: cargo test --features=test brew -- --ignored
+          targets: x86_64-apple-darwin
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-apple-darwin
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test brew
+          cargo test --features=test brew -- --ignored
 
   port-test:
     runs-on: macos-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
@@ -119,7 +169,7 @@ jobs:
           cat macos_build.txt
       # https://github.com/actions/cache/issues/629#issuecomment-1189184648
       - name: Create gtar wrapper
-        uses: 1arp/create-a-file-action@0.2
+        uses: fertrig/create-file-action@1.0.2
         with:
           path: target
           file: gtar
@@ -146,176 +196,216 @@ jobs:
           curl -LO https://raw.githubusercontent.com/GiovanniBussi/macports-ci/master/macports-ci
           source ./macports-ci install
           sudo port install wget
+          port installed
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --verbose
-      - run: port installed
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test port
-      - name: Run heavy tests
-        run: cargo test --features=test port -- --ignored
+        with:
+          targets: x86_64-apple-darwin
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-apple-darwin
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test port
+          cargo test --features=test port -- --ignored
 
   apt-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
-    env:
-      # https://users.rust-lang.org/t/cross-compiling-how-to-statically-link-glibc/83907/2
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
     steps:
       - uses: actions/checkout@v3
-      - name: Setup extra build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v2
-      - name: Test build for aarch64 musl
-        run: cargo build --verbose --release --locked --target=aarch64-unknown-linux-musl
-      - name: Test build for x86_64 musl
-        run: cargo build --verbose --release --locked --target=x86_64-unknown-linux-musl
-      - name: Test native build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test apt
-      - name: Run heavy tests
-        run: cargo test --features=test apt -- --ignored
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test apt
+          cargo test --features=test apt -- --ignored
 
   dnf-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     container:
       image: fedora:latest
     steps:
       - uses: actions/checkout@v3
-      - run: dnf install -y make automake gcc gcc-c++ kernel-devel
+      - name: Setup extra build tools
+        run: dnf install -y make automake gcc gcc-c++ kernel-devel
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test dnf
-      - name: Run heavy tests
-        run: cargo test --features=test dnf -- --ignored
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test dnf
+          cargo test --features=test dnf -- --ignored
 
   emerge-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     container:
       image: gentoo/stage3
     steps:
       - uses: actions/checkout@v3
+      - name: Setup extra build tools
+        run: |
+          # `pacaptr -Ss` might fail without this line.
+          emerge --sync || true
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      # `pacaptr -Ss` might fail without this line.
-      - run: emerge --sync || true
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test emerge
-      - name: Run heavy tests
-        run: cargo test --features=test emerge -- --ignored
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test emerge
+          cargo test --features=test emerge -- --ignored
 
   xbps-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     container:
       image: voidlinux/voidlinux:latest
     steps:
-      - name: Install required packages
+      - name: Setup extra build tools
         run: |
           xbps-install -y -Su || (xbps-install -y -u xbps && xbps-install -y -Su)
           xbps-install -y base-devel curl bash
       - uses: actions/checkout@v3
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test xbps
-      - name: Run heavy tests
-        run: cargo test --features=test xbps -- --ignored
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test xbps
+          cargo test --features=test xbps -- --ignored
 
   zypper-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     container:
-      image: opensuse/leap:latest
+      image: registry.opensuse.org/opensuse/bci/rust:latest
     steps:
-      - run: zypper install -y tar gzip curl gcc bash
+      - name: Setup extra build tools
+        run: zypper install -y tar gzip curl gcc bash
       - uses: actions/checkout@v3
-      #  uses: dtolnay/rust-toolchain@stable
-      - name: Set up Rust environment manually
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: $HOME/.cargo/bin/cargo build --verbose
-      - name: Run unit tests
-        run: $HOME/.cargo/bin/cargo test --features=test tests
-      - name: Run smoke tests
-        run: $HOME/.cargo/bin/cargo test --features=test zypper -- --test-threads=1
-      - name: Run heavy tests
-        run: $HOME/.cargo/bin/cargo test --features=test zypper -- --ignored --test-threads=1
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test zypper -- --test-threads=1
+          cargo test --features=test zypper -- --ignored --test-threads=1
 
   apk-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     container:
       image: rust:alpine
-    env:
-      RUSTFLAGS: "-C target-feature=-crt-static"
     steps:
+      - name: Setup extra build tools
+        run: |
+          apk add -U build-base tar bash
       - uses: actions/checkout@v3
-      - run: apk add -U build-base tar bash
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run unit tests
-        run: cargo test --features=test tests
-      - name: Run smoke tests
-        run: cargo test --features=test apk
-      - name: Run heavy tests
-        run: cargo test --features=test apk -- --ignored
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          RUSTFLAGS: "-C target-feature=-crt-static"
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+        run: |
+          cargo build --verbose
+          cargo test --features=test tests
+          cargo test --features=test apk
+          cargo test --features=test apk -- --ignored
 
   pkcon-pip-conda-test:
     runs-on: ubuntu-latest
-    needs: skip-check
+    needs: build
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup extra build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y packagekit packagekit-tools gcc-aarch64-linux-gnu
+      - name: Download cached build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pacaptr-test-${{ runner.os }}-${{ runner.arch }}
+          save-if: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: |
-          sudo apt update
-          sudo apt install -y packagekit packagekit-tools
-      - name: Build
-        run: cargo build --verbose
-      - name: Run smoke tests
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build and run tests
+        env:
+          CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
         run: |
-          cargo test --features=test pkcon 
-          cargo test --features=test pip 
+          cargo build --verbose
+
+          cargo test --features=test pkcon
+          cargo test --features=test pip
           cargo test --features=test conda
-      - name: Run heavy tests
-        run: |
+
           cargo test --features=test pkcon -- --ignored
           cargo test --features=test pip -- --ignored
           cargo test --features=test conda -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6f84b74db2535ebae81eede2f39b947dcbf01d093ae5f791e5dd414a1bf289"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-trait"
@@ -89,7 +89,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -127,9 +127,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "built"
@@ -167,11 +167,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -182,9 +183,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -193,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstream",
  "anstyle",
@@ -213,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -295,9 +296,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -580,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litrs"
@@ -595,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -709,7 +710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.28",
+ "syn 2.0.29",
  "tabled",
 ]
 
@@ -750,7 +751,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -818,16 +819,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -898,11 +899,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.7"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -920,22 +921,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -990,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1031,9 +1032,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1044,22 +1045,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1089,9 +1090,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1112,7 +1113,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1330,7 +1331,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1350,17 +1351,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1371,9 +1372,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1383,9 +1384,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1395,9 +1396,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1407,9 +1408,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1419,9 +1420,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1431,9 +1432,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1443,15 +1444,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.1"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]
@@ -1473,9 +1474,9 @@ checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 
 [[package]]
 name = "yansi"
-version = "1.0.0-rc"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee746ad3851dd3bc40e4a028ab3b00b99278d929e48957bcb2d111874a7e43e"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ xshell = "0.2.5"
 [dependencies]
 async-trait = "0.1.73"
 bytes = "1.4.0"
-clap = { version = "4.3.21", features = ["cargo", "derive"] }
+clap = { version = "4.3.23", features = ["cargo", "derive"] }
 console = "0.15.7"
 dialoguer = { version = "0.10.4", features = ["fuzzy-select"] }
 dirs-next = "2.0.0"
@@ -74,10 +74,10 @@ regex = { version = "1.9.3", default-features = false, features = [
   "unicode-case",
   "unicode-perl",
 ] }
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { version = "1.0.185", features = ["derive"] }
 tap = "1.0.1"
-thiserror = "1.0.46"
-tokio = { version = "1.31.0", features = [
+thiserror = "1.0.47"
+tokio = { version = "1.32.0", features = [
   "io-std",
   "io-util",
   "macros",

--- a/crates/pacaptr-macros/Cargo.toml
+++ b/crates/pacaptr-macros/Cargo.toml
@@ -15,12 +15,12 @@ description = "Implementation of several macros used in pacaptr."
 proc-macro = true
 
 [dependencies]
-anyhow = "1.0.74"
+anyhow = "1.0.75"
 itertools = "0.11.0"
 litrs = "0.4.0"
 once_cell = "1.18.0"
 proc-macro2 = "1.0.66"
-quote = "1.0.32"
+quote = "1.0.33"
 regex = "1.9.3"
-syn = "2.0.28"
+syn = "2.0.29"
 tabled = "0.14.0"

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -410,10 +410,12 @@ pub fn grep_print(text: &str, patterns: &[&str]) -> Result<()> {
 /// changes.
 #[doc = docs_errors_grep!()]
 pub fn grep_print_with_header(text: &str, patterns: &[&str], header_lines: usize) -> Result<()> {
-    let lns = text.lines();
-    lns.take(header_lines).for_each(|ln| println!("{ln}"));
-    grep(text, patterns)?
-        .into_iter()
+    let lns = text.lines().collect_vec();
+    let (header, rest) = lns.split_at(header_lines);
+    header
+        .iter()
+        .copied()
+        .chain(grep(&rest.join("\n"), patterns)?)
         .for_each(|ln| println!("{ln}"));
     Ok(())
 }

--- a/src/pm/zypper.rs
+++ b/src/pm/zypper.rs
@@ -224,7 +224,7 @@ impl Pm for Zypper {
             .check_output(cmd, PmMode::Mute, &STRAT_CHECK_DRY)
             .await?
             .pipe(String::from_utf8)?;
-        exec::grep_print_with_header(&out, kws, 2)
+        exec::grep_print_with_header(&out, kws, 4)
     }
 
     /// Ss searches for package(s) by searching the expression in name,

--- a/src/pm/zypper.rs
+++ b/src/pm/zypper.rs
@@ -224,7 +224,7 @@ impl Pm for Zypper {
             .check_output(cmd, PmMode::Mute, &STRAT_CHECK_DRY)
             .await?
             .pipe(String::from_utf8)?;
-        exec::grep_print(&out, kws)
+        exec::grep_print_with_header(&out, kws, 2)
     }
 
     /// Ss searches for package(s) by searching the expression in name,

--- a/tests/zypper.rs
+++ b/tests/zypper.rs
@@ -108,11 +108,9 @@ fn zypper_si() {
 #[test]
 fn zypper_sl() {
     test_dsl! { r##"
-        in -Sl
-        ou Main Repository
-        ou wget
         in -Sl wget
-        ou Main Repository
+        ou Repository
+        ou openSUSE
         ou wget
     "## }
 }


### PR DESCRIPTION
Closes #634.

---

The plan to fix this issue is as follows:

- [x] Build all targets for `x86_64-pc-windows-msvc`, `x86_64-apple-darwin` and `x86_64-unknown-linux-musl`, and upload `target/{{ triple }}/`.
  - [x] Meanwhile, build `--release --locked` for `aarch64-pc-windows-msvc`, `aarch64-apple-darwin` and `aarch64-unknown-linux-musl`, ~~ideally without any kind of uploads~~.
- [x] Download `target/` and continue with the test.