### PR TITLE
fix(pm): fix `-Sy` for `winget`

### DIFF
--- a/src/pm/winget.rs
+++ b/src/pm/winget.rs
@@ -139,7 +139,7 @@ impl Pm for Winget {
 
     /// Sy refreshes the local package database.
     async fn sy(&self, kws: &[&str], flags: &[&str]) -> Result<()> {
-        Cmd::new(["winget", "source", "update", "--accept-source-agreements"])
+        Cmd::new(["winget", "source", "update"])
             .flags(flags)
             .pipe(|cmd| self.run(cmd))
             .await?;


### PR DESCRIPTION
The command `winget source update`, which is used by `-Sy`, does not support the applied flag `--accept-source-agreements` (neither [documented](https://web.archive.org/web/20260804193431/https://learn.microsoft.com/en-us/windows/package-manager/winget/source#update) nor hidden) in the [current version](https://github.com/microsoft/winget-cli/releases/tag/v1.29.280), so this PR removes it.

Before this change, `winget` shows the error message "Argument name was not recognized for the current command: '--accept-source-agreement'" followed by the help message for the command.